### PR TITLE
feat: add st discover command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
         script: |
           const body = context.payload.comment.body.trim();
           const match = body.match(
-            /^(?:stack|st)\s+(merge-all|merge|restack|help)\b(.*)$/i
+            /^(?:stack|st)\s+(merge-all|merge|restack|discover|help)\b(.*)$/i
           );
           if (!match) {
             core.setOutput('valid', 'false');
@@ -79,14 +79,14 @@ runs:
           });
 
     - name: Checkout
-      if: steps.cmd.outputs.valid == 'true' && steps.cmd.outputs.command != 'help'
+      if: steps.cmd.outputs.valid == 'true' && steps.cmd.outputs.command != 'help' && steps.cmd.outputs.command != 'discover'
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
         token: ${{ steps.app-token.outputs.token || inputs.token }}
 
     - name: Configure git
-      if: steps.cmd.outputs.valid == 'true' && steps.cmd.outputs.command != 'help'
+      if: steps.cmd.outputs.valid == 'true' && steps.cmd.outputs.command != 'help' && steps.cmd.outputs.command != 'discover'
       shell: bash
       run: |
         git config user.name "github-actions[bot]"

--- a/src/guide.js
+++ b/src/guide.js
@@ -41,6 +41,7 @@ module.exports = async function guide({ github, context }) {
     '| `stack merge-all` (`st merge-all`) | Merge entire stack (requires all approved) |',
     '| `stack merge-all --force` (`st merge-all --force`) | Merge entire stack (skip approval check) |',
     '| `stack restack` (`st restack`) | Restack children without merging |',
+    '| `stack discover` (`st discover`) | Auto-discover stack tree from base branches |',
     '',
     `**Stack:** ${stack}`,
   ].join('\n');


### PR DESCRIPTION
## Summary
- Add `st discover` command that auto-detects stack tree by scanning open PRs' base branch relationships
- Uses GitHub compare API to detect which children need restacking (⚠️ indicator)
- Automatically updates PR body metadata for all discovered PRs
- No git operations needed (API-only), skips checkout like `st help`

## Test plan
- [ ] Merge this PR to main
- [ ] Create test stacked branches and PRs
- [ ] Re-target PRs to form a stack via `gh api`
- [ ] Comment `st discover` on the root PR
- [ ] Verify metadata is set and restack status is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)