### PR TITLE
fix: defer parent branch deletion in merge-all

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -430,9 +430,8 @@ module.exports = async function command({ github, context, core, exec, command, 
       return;
     }
 
-    await deleteBranch(freshPr.head.ref);
-
     if (!freshChildren.length) {
+      await deleteBranch(freshPr.head.ref);
       await post(prNumber, `Merged into \`${freshBaseBranch}\`.`);
       return;
     }
@@ -440,6 +439,11 @@ module.exports = async function command({ github, context, core, exec, command, 
     const results = await restackChildren(
       freshChildren, freshBaseBranch, freshPr.head.sha
     );
+
+    // Delete parent branch after children are restacked,
+    // so child PRs' base branch still exists during restackChildren.
+    await deleteBranch(freshPr.head.ref);
+
     const ok = results.every(r => r.status === 'restacked');
 
     await post(prNumber, [
@@ -585,11 +589,13 @@ module.exports = async function command({ github, context, core, exec, command, 
       }
     }
 
-    await mergeChildren(freshChildren, freshPr.head.sha);
-
-    // Delete root branch after all children are processed,
-    // so child PRs' base branch still exists during mergeChildren.
-    await deleteBranch(freshPr.head.ref);
+    try {
+      await mergeChildren(freshChildren, freshPr.head.sha);
+    } finally {
+      // Delete root branch after all children are processed,
+      // so child PRs' base branch still exists during mergeChildren.
+      await deleteBranch(freshPr.head.ref);
+    }
 
     const allMerged = results.every(r => r.status === 'merged');
     const mergedCount =


### PR DESCRIPTION

  ## Summary                                                                      
                                                                                  
  • Move deleteBranch after mergeChildren in merge-all flow so child PRs' base   
  branch still exists during processing                                           
  • Fixes: when merge-all merges root PR and deletes its branch, GitHub auto-    
  closes child PRs (base branch deleted), making subsequent rebase/merge          
  operations fail silently                                                        
                                                                                  
  ## Root cause                                                                   
                                                                                  
    Before: tryMerge(root) → deleteBranch(parent) → mergeChildren(...)          
                              ↑ child PRs auto-closed                            
                                                                                  
    After:  tryMerge(root) → mergeChildren(...) → deleteBranch(parent)          
                              ↑ base branch still exists                         
                                                                                  
  ## Test plan                                                                    
                                                                                  
  [ ] Create 3 stacked test PRs (qa-base → stack-1 → stack-2 → stack-3)        
  [ ] Run st merge-all --force on root PR                                         
  [ ] Verify all child PRs are merged (not auto-closed)                           
  [ ] Verify branches are deleted after completion                                
                                                                                  
  🤖 Generated with Claude Code https://claude.com/claude-code                    