### PR TITLE
fix: defer child branch deletion in mergeChildren

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -579,13 +579,15 @@ module.exports = async function command({ github, context, core, exec, command, 
         }
 
         results.push({ ...child, status: 'merged', oldTip, order });
-        await deleteBranch(child.branch);
 
-        // Recursively process this child's children
+        // Recursively process this child's children before deleting branch,
+        // so grandchild PRs' base branch still exists during processing.
         const { meta: childMeta } = await getStackMeta(child.pr);
         if (childMeta?.children?.length) {
           await mergeChildren(childMeta.children, oldTip);
         }
+
+        await deleteBranch(child.branch);
       }
     }
 


### PR DESCRIPTION

  ## Summary                                                                      
                                                                                  
  • Same bug pattern as #19 but inside mergeChildren: deleteBranch(child.branch) 
  ran before recursing into grandchildren                                         
  • This caused grandchild PRs to be auto-closed by GitHub (base branch deleted) 
                                                                                  
  ## Evidence from QA                                                             
                                                                                  
  After #19 fix: PR #20 and #21 merged successfully (2/3), but PR #22 was auto-   
  closed at 07:13:30Z right after PR #21 merged at 07:13:28Z                      
                                                                                  
  ## Test plan                                                                    
                                                                                  
  [ ] Create 3 stacked test PRs                                                   
  [ ] Run st merge-all --force and verify all 3 PRs merge (3/3)                   
                                                                                  
  🤖 Generated with Claude Code https://claude.com/claude-code                    