### PR TITLE
fix: split workflows by event + clean up docs

### DIFF
--- a/.github/workflows/dogfood-auto-detect.yml
+++ b/.github/workflows/dogfood-auto-detect.yml
@@ -1,3 +1,4 @@
+# Dogfood: tests the composite action directly from this repo (uses: ./)
 name: Staqd Auto Detect (dogfood)
 
 on:

--- a/.github/workflows/dogfood-auto-detect.yml
+++ b/.github/workflows/dogfood-auto-detect.yml
@@ -1,0 +1,15 @@
+name: Staqd Auto Detect (dogfood)
+
+on:
+  pull_request:
+    types: [opened, edited, closed]
+
+jobs:
+  auto-detect:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./

--- a/.github/workflows/dogfood-command.yml
+++ b/.github/workflows/dogfood-command.yml
@@ -1,3 +1,4 @@
+# Dogfood: tests the composite action directly from this repo (uses: ./)
 name: Staqd Command (dogfood)
 
 on:

--- a/.github/workflows/dogfood-command.yml
+++ b/.github/workflows/dogfood-command.yml
@@ -1,28 +1,14 @@
-name: Staqd (dogfood)
+name: Staqd Command (dogfood)
 
 on:
-  pull_request:
-    types: [opened, edited, closed]
   issue_comment:
     types: [created]
 
 jobs:
-  # Guide comment — no concurrency needed (idempotent)
-  guide:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
-    steps:
-      - uses: actions/checkout@v6  # needed for uses: ./
-      - uses: ./  # dogfood: use local action
-
   # Resolve base branch for concurrency group
   resolve-base:
     if: >-
-      github.event_name == 'issue_comment'
-      && github.event.issue.pull_request
+      github.event.issue.pull_request
       && (startsWith(github.event.comment.body, 'stack ') || startsWith(github.event.comment.body, 'st '))
     runs-on: ubuntu-latest
     permissions:
@@ -54,5 +40,5 @@ jobs:
       issues: write
       checks: read
     steps:
-      - uses: actions/checkout@v6  # needed for uses: ./
-      - uses: ./  # dogfood: use local action
+      - uses: actions/checkout@v6
+      - uses: ./

--- a/.github/workflows/staqd-auto-detect.yml
+++ b/.github/workflows/staqd-auto-detect.yml
@@ -1,0 +1,33 @@
+name: Staqd Auto Detect
+
+on:
+  workflow_call:
+    inputs:
+      app-id:
+        description: 'GitHub App ID. Used with app-private-key to generate an installation token.'
+        type: string
+        required: false
+        default: ''
+      runs-on:
+        description: 'Runner label for all jobs (default: ubuntu-latest)'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+    secrets:
+      app-private-key:
+        description: 'GitHub App private key. Used with app-id to generate an installation token.'
+        required: false
+
+jobs:
+  # Guide comment — no concurrency needed (idempotent)
+  auto-detect:
+    runs-on: ${{ inputs.runs-on }}
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: siner308/staqd@v1
+        with:
+          token: ${{ github.token }}
+          app-id: ${{ inputs.app-id }}
+          app-private-key: ${{ secrets.app-private-key }}

--- a/.github/workflows/staqd-command.yml
+++ b/.github/workflows/staqd-command.yml
@@ -1,0 +1,66 @@
+name: Staqd Command
+
+on:
+  workflow_call:
+    inputs:
+      app-id:
+        description: 'GitHub App ID. Used with app-private-key to generate an installation token.'
+        type: string
+        required: false
+        default: ''
+      runs-on:
+        description: 'Runner label for all jobs (default: ubuntu-latest)'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+      timeout-minutes:
+        description: 'Timeout for the command job in minutes (default: 30)'
+        type: number
+        required: false
+        default: 30
+    secrets:
+      app-private-key:
+        description: 'GitHub App private key. Used with app-id to generate an installation token.'
+        required: false
+
+jobs:
+  # Resolve base branch for concurrency group
+  resolve-base:
+    if: >-
+      github.event.issue.pull_request
+      && (startsWith(github.event.comment.body, 'stack ') || startsWith(github.event.comment.body, 'st '))
+    runs-on: ${{ inputs.runs-on }}
+    permissions:
+      pull-requests: read
+    outputs:
+      base-ref: ${{ steps.get.outputs.base-ref }}
+    steps:
+      - id: get
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.payload.issue.number,
+            });
+            core.setOutput('base-ref', pr.base.ref);
+
+  # Execute command — serialized per base branch
+  command:
+    needs: resolve-base
+    concurrency:
+      group: staqd-${{ needs.resolve-base.outputs.base-ref }}
+      cancel-in-progress: false
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      checks: read
+    steps:
+      - uses: siner308/staqd@v1
+        with:
+          token: ${{ github.token }}
+          app-id: ${{ inputs.app-id }}
+          app-private-key: ${{ secrets.app-private-key }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 **/stakt/** — like "stacked"
 
 Stacked PR merge queue powered by GitHub Actions and PR comments.
-No CLI to install. No SaaS dependency. One workflow file is all you need.
 
 ## Usage
 
@@ -62,8 +61,19 @@ That's it. Each workflow triggers only on its relevant event, keeping PR checks 
 
 ### With GitHub App (recommended for CI auto-trigger)
 
+`.github/workflows/staqd-auto-detect.yml`:
+
 ```yaml
-# staqd-auto-detect.yml
+name: Staqd Auto Detect
+
+on:
+  pull_request:
+    types: [opened, edited, closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   staqd:
     uses: siner308/staqd/.github/workflows/staqd-auto-detect.yml@v1
@@ -71,8 +81,23 @@ jobs:
       app-id: ${{ vars.STAQD_APP_ID }}
     secrets:
       app-private-key: ${{ secrets.STAQD_APP_PRIVATE_KEY }}
+```
 
-# staqd-command.yml
+`.github/workflows/staqd-command.yml`:
+
+```yaml
+name: Staqd Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: read
+
 jobs:
   staqd:
     uses: siner308/staqd/.github/workflows/staqd-command.yml@v1
@@ -82,7 +107,7 @@ jobs:
       app-private-key: ${{ secrets.STAQD_APP_PRIVATE_KEY }}
 ```
 
-> **Note:** The single-file `staqd.yml` workflow still works for backward compatibility, but may show skipped jobs in branch protection checks.
+> **Deprecation:** The single-file `staqd.yml` is deprecated. Use the two-file setup above.
 
 ### Reusable Workflow Inputs
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,32 @@ No CLI to install. No SaaS dependency. One workflow file is all you need.
 
 ### Basic
 
+Add a workflow file for each of the two events:
+
+`.github/workflows/staqd-auto-detect.yml` — runs on pull request events:
+
 ```yaml
-name: Staqd
+name: Staqd Auto Detect
 
 on:
   pull_request:
     types: [opened, edited, closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  staqd:
+    uses: siner308/staqd/.github/workflows/staqd-auto-detect.yml@v1
+```
+
+`.github/workflows/staqd-command.yml` — runs on PR comment commands:
+
+```yaml
+name: Staqd Command
+
+on:
   issue_comment:
     types: [created]
 
@@ -35,24 +55,45 @@ permissions:
 
 jobs:
   staqd:
-    uses: siner308/staqd/.github/workflows/staqd.yml@v1
+    uses: siner308/staqd/.github/workflows/staqd-command.yml@v1
 ```
 
-That's it. The reusable workflow handles everything internally: guide comments, base branch resolution, concurrency groups, and command execution.
+That's it. Each workflow triggers only on its relevant event, keeping PR checks clean and focused.
 
 ### With GitHub App (recommended for CI auto-trigger)
 
 ```yaml
+# staqd-auto-detect.yml
 jobs:
   staqd:
-    uses: siner308/staqd/.github/workflows/staqd.yml@v1
+    uses: siner308/staqd/.github/workflows/staqd-auto-detect.yml@v1
+    with:
+      app-id: ${{ vars.STAQD_APP_ID }}
+    secrets:
+      app-private-key: ${{ secrets.STAQD_APP_PRIVATE_KEY }}
+
+# staqd-command.yml
+jobs:
+  staqd:
+    uses: siner308/staqd/.github/workflows/staqd-command.yml@v1
     with:
       app-id: ${{ vars.STAQD_APP_ID }}
     secrets:
       app-private-key: ${{ secrets.STAQD_APP_PRIVATE_KEY }}
 ```
 
+> **Note:** The single-file `staqd.yml` workflow still works for backward compatibility, but may show skipped jobs in branch protection checks.
+
 ### Reusable Workflow Inputs
+
+**`staqd-auto-detect.yml`**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `app-id` | GitHub App ID. Used with `app-private-key` to generate an installation token. | No | |
+| `runs-on` | Runner label for all jobs | No | `ubuntu-latest` |
+
+**`staqd-command.yml`**
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Staqd'
-description: 'Stacked PR merge queue powered by GitHub Actions and PR comments. No CLI, no SaaS.'
+description: 'Stacked PR merge queue powered by GitHub Actions and PR comments.'
 author: 'siner308'
 
 branding:

--- a/docs/index.html
+++ b/docs/index.html
@@ -987,18 +987,39 @@
   <section id="quickstart">
     <div class="container">
       <h2 id="quickstart-heading"><span data-i18n="quickstart.heading">Quick Start</span><a href="#quickstart-heading" class="anchor-link" aria-label="Link to this section">#</a></h2>
-      <p class="section-intro" data-i18n-html="quickstart.intro">Add this workflow to <code>.github/workflows/staqd.yml</code></p>
+      <p class="section-intro" data-i18n-html="quickstart.intro">Add a workflow file for each of the two events:</p>
 
+      <p style="margin-bottom: 0.5rem; font-weight: 600;"><code>.github/workflows/staqd-auto-detect.yml</code></p>
       <div class="code-block">
         <div class="code-header">
           <span class="code-lang">YAML</span>
           <button class="copy-btn" data-i18n="common.copy" onclick="copyCode(this)">Copy</button>
         </div>
-        <pre><code><span class="code-keyword">name:</span> Staqd
+        <pre><code><span class="code-keyword">name:</span> Staqd Auto Detect
 
 <span class="code-keyword">on:</span>
   <span class="code-property">pull_request:</span>
     <span class="code-property">types:</span> [opened, edited, closed]
+
+<span class="code-keyword">permissions:</span>
+  <span class="code-property">pull-requests:</span> write
+  <span class="code-property">issues:</span> write
+
+<span class="code-keyword">jobs:</span>
+  <span class="code-property">staqd:</span>
+    <span class="code-keyword">uses:</span> siner308/staqd/.github/workflows/staqd-auto-detect.yml@v1
+</code></pre>
+      </div>
+
+      <p style="margin-top: 1.5rem; margin-bottom: 0.5rem; font-weight: 600;"><code>.github/workflows/staqd-command.yml</code></p>
+      <div class="code-block">
+        <div class="code-header">
+          <span class="code-lang">YAML</span>
+          <button class="copy-btn" data-i18n="common.copy" onclick="copyCode(this)">Copy</button>
+        </div>
+        <pre><code><span class="code-keyword">name:</span> Staqd Command
+
+<span class="code-keyword">on:</span>
   <span class="code-property">issue_comment:</span>
     <span class="code-property">types:</span> [created]
 
@@ -1010,7 +1031,7 @@
 
 <span class="code-keyword">jobs:</span>
   <span class="code-property">staqd:</span>
-    <span class="code-keyword">uses:</span> siner308/staqd/.github/workflows/staqd.yml@v1
+    <span class="code-keyword">uses:</span> siner308/staqd/.github/workflows/staqd-command.yml@v1
 </code></pre>
       </div>
     </div>
@@ -1288,7 +1309,7 @@ feat-2:              E'───F'   <span class="code-comment">(C, D removed; o
         'features.justYamlDesc': 'One workflow file. Copy, commit, done. Stack metadata lives in PR body comments.',
 
         'quickstart.heading': 'Quick Start',
-        'quickstart.intro': 'Add this workflow to <code>.github/workflows/staqd.yml</code>',
+        'quickstart.intro': 'Add a workflow file for each of the two events:',
 
         'commands.heading': 'Commands',
         'commands.intro': 'Comment on a PR to trigger actions. All commands support the short alias <code>st</code> (e.g., <code>st merge</code>).',
@@ -1391,7 +1412,7 @@ feat-2:              E'───F'   <span class="code-comment">(C, D removed; o
         'features.justYamlDesc': '워크플로우 파일 하나만 추가하면 됩니다. 복사하고 커밋하면 준비 완료. 스택 메타데이터는 PR 본문에 저장됩니다.',
 
         'quickstart.heading': '빠른 시작',
-        'quickstart.intro': '<code>.github/workflows/staqd.yml</code>에 이 워크플로우를 추가하세요',
+        'quickstart.intro': '두 가지 이벤트에 대한 각각의 워크플로우 파일을 추가하세요:',
 
         'commands.heading': '명령어',
         'commands.intro': 'PR에 코멘트를 남겨 작업을 실행하세요. 모든 명령어는 단축 별칭 <code>st</code>를 지원합니다 (예: <code>st merge</code>).',

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,12 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <title>Staqd — Stacked PR merge queue powered by GitHub Actions</title>
-  <meta name="description" content="No CLI to install. No SaaS dependency. One workflow file is all you need.">
+  <meta name="description" content="Stacked PR merge queue powered by GitHub Actions and PR comments.">
 
   <!-- OpenGraph -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="Staqd — Stacked PR merge queue">
-  <meta property="og:description" content="Stacked PR merge queue powered by GitHub Actions and PR comments. No CLI, no SaaS, one workflow file.">
+  <meta property="og:description" content="Stacked PR merge queue powered by GitHub Actions and PR comments.">
   <meta property="og:url" content="https://siner308.github.io/staqd/">
   <meta property="og:image" content="https://siner308.github.io/staqd/social-preview.png">
   <meta property="og:image:width" content="1280">
@@ -20,7 +20,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Staqd — Stacked PR merge queue">
-  <meta name="twitter:description" content="Stacked PR merge queue powered by GitHub Actions and PR comments. No CLI, no SaaS, one workflow file.">
+  <meta name="twitter:description" content="Stacked PR merge queue powered by GitHub Actions and PR comments.">
   <meta name="twitter:image" content="https://siner308.github.io/staqd/social-preview.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -398,64 +398,6 @@
       margin-bottom: 3rem;
     }
 
-    /* Zero Setup Badges */
-    .badges {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 1.5rem;
-      margin-top: 3rem;
-    }
-
-    .badge-card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 2.5rem 2rem;
-      text-align: center;
-      transition: all 0.3s ease;
-      position: relative;
-      overflow: hidden;
-    }
-
-    .badge-card::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 3px;
-      background: linear-gradient(90deg, var(--purple), var(--green));
-      transform: scaleX(0);
-      transform-origin: left;
-      transition: transform 0.3s ease;
-    }
-
-    .badge-card:hover::before {
-      transform: scaleX(1);
-    }
-
-    .badge-card:hover {
-      transform: translateY(-4px);
-      border-color: var(--purple);
-      box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
-    }
-
-    .badge-icon {
-      font-size: 3rem;
-      margin-bottom: 1rem;
-    }
-
-    .badge-card h3 {
-      font-size: 1.5rem;
-      margin-bottom: 0.5rem;
-      color: var(--purple);
-    }
-
-    .badge-card p {
-      color: var(--text-dim);
-      font-size: 0.95rem;
-    }
-
     /* Code Block */
     .code-block {
       background: var(--surface);
@@ -779,10 +721,6 @@
         min-height: 80vh;
       }
 
-      .badges {
-        grid-template-columns: 1fr;
-      }
-
       .hero-cta {
         flex-direction: column;
         width: 100%;
@@ -956,31 +894,6 @@
       <a href="#quickstart" class="btn btn-secondary" data-i18n="hero.getStarted">Get Started</a>
     </div>
     <div class="scroll-hint">↓</div>
-  </section>
-
-  <!-- Zero Setup -->
-  <section id="features">
-    <div class="container">
-      <h2 id="features-heading"><span data-i18n="features.heading">Zero Setup Tax</span><a href="#features-heading" class="anchor-link" aria-label="Link to this section">#</a></h2>
-      <p class="section-intro" data-i18n="features.intro">No CLI to install. No SaaS dependency. One workflow file is all you need.</p>
-      <div class="badges">
-        <div class="badge-card">
-          <div class="badge-icon">🚫</div>
-          <h3 data-i18n="features.noCli">No CLI</h3>
-          <p data-i18n="features.noCliDesc">Pure GitHub Actions. No binary to install, update, or maintain across your team.</p>
-        </div>
-        <div class="badge-card">
-          <div class="badge-icon">☁️</div>
-          <h3 data-i18n="features.noSaas">No SaaS</h3>
-          <p data-i18n="features.noSaasDesc">No external service, no account creation, no API quotas. Your repo, your control.</p>
-        </div>
-        <div class="badge-card">
-          <div class="badge-icon">📄</div>
-          <h3 data-i18n="features.justYaml">Just YAML</h3>
-          <p data-i18n="features.justYamlDesc">One workflow file. Copy, commit, done. Stack metadata lives in PR body comments.</p>
-        </div>
-      </div>
-    </div>
   </section>
 
   <!-- Quick Start -->
@@ -1299,15 +1212,6 @@ feat-2:              E'───F'   <span class="code-comment">(C, D removed; o
         'hero.viewGithub': 'View on GitHub',
         'hero.getStarted': 'Get Started',
 
-        'features.heading': 'Zero Setup Tax',
-        'features.intro': 'No CLI to install. No SaaS dependency. One workflow file is all you need.',
-        'features.noCli': 'No CLI',
-        'features.noCliDesc': 'Pure GitHub Actions. No binary to install, update, or maintain across your team.',
-        'features.noSaas': 'No SaaS',
-        'features.noSaasDesc': 'No external service, no account creation, no API quotas. Your repo, your control.',
-        'features.justYaml': 'Just YAML',
-        'features.justYamlDesc': 'One workflow file. Copy, commit, done. Stack metadata lives in PR body comments.',
-
         'quickstart.heading': 'Quick Start',
         'quickstart.intro': 'Add a workflow file for each of the two events:',
 
@@ -1401,15 +1305,6 @@ feat-2:              E'───F'   <span class="code-comment">(C, D removed; o
         'hero.tagline': 'GitHub Actions와 PR 코멘트로 동작하는 Stacked PR 머지 큐',
         'hero.viewGithub': 'GitHub에서 보기',
         'hero.getStarted': '시작하기',
-
-        'features.heading': '설정 없이 바로 시작하세요',
-        'features.intro': 'CLI를 설치할 필요 없습니다. SaaS에 의존하지 않습니다. 워크플로우 파일 하나면 충분합니다.',
-        'features.noCli': 'CLI 없음',
-        'features.noCliDesc': '순수 GitHub Actions 기반입니다. 팀 전체에 별도로 설치하거나 관리할 바이너리가 없습니다.',
-        'features.noSaas': 'SaaS 없음',
-        'features.noSaasDesc': '외부 서비스도, 계정 생성도, API 할당량도 필요 없습니다. 당신의 저장소에서 직접 관리하세요.',
-        'features.justYaml': 'YAML 하나면 끝',
-        'features.justYamlDesc': '워크플로우 파일 하나만 추가하면 됩니다. 복사하고 커밋하면 준비 완료. 스택 메타데이터는 PR 본문에 저장됩니다.',
 
         'quickstart.heading': '빠른 시작',
         'quickstart.intro': '두 가지 이벤트에 대한 각각의 워크플로우 파일을 추가하세요:',

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3,7 +3,6 @@
 /stakt/ — like "stacked"
 
 Stacked PR merge queue powered by GitHub Actions and PR comments.
-No CLI to install. No SaaS dependency. One workflow file is all you need.
 
 ## Quick Start
 
@@ -49,12 +48,23 @@ jobs:
 
 Each workflow triggers only on its relevant event, keeping PR checks clean and focused.
 
-Note: The single-file `staqd.yml` workflow still works for backward compatibility, but may show skipped jobs in branch protection checks.
+Deprecation: The single-file `staqd.yml` is deprecated. Use the two-file setup above.
 
 ### With GitHub App (recommended for CI auto-trigger)
 
+`.github/workflows/staqd-auto-detect.yml`:
+
 ```yaml
-# staqd-auto-detect.yml
+name: Staqd Auto Detect
+
+on:
+  pull_request:
+    types: [opened, edited, closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
 jobs:
   staqd:
     uses: siner308/staqd/.github/workflows/staqd-auto-detect.yml@v1
@@ -62,8 +72,23 @@ jobs:
       app-id: ${{ vars.STAQD_APP_ID }}
     secrets:
       app-private-key: ${{ secrets.STAQD_APP_PRIVATE_KEY }}
+```
 
-# staqd-command.yml
+`.github/workflows/staqd-command.yml`:
+
+```yaml
+name: Staqd Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: read
+
 jobs:
   staqd:
     uses: siner308/staqd/.github/workflows/staqd-command.yml@v1

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7,14 +7,32 @@ No CLI to install. No SaaS dependency. One workflow file is all you need.
 
 ## Quick Start
 
-Add this workflow to `.github/workflows/staqd.yml`:
+Add a workflow file for each of the two events:
+
+`.github/workflows/staqd-auto-detect.yml` — runs on pull request events:
 
 ```yaml
-name: Staqd
+name: Staqd Auto Detect
 
 on:
   pull_request:
     types: [opened, edited, closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  staqd:
+    uses: siner308/staqd/.github/workflows/staqd-auto-detect.yml@v1
+```
+
+`.github/workflows/staqd-command.yml` — runs on PR comment commands:
+
+```yaml
+name: Staqd Command
+
+on:
   issue_comment:
     types: [created]
 
@@ -26,17 +44,29 @@ permissions:
 
 jobs:
   staqd:
-    uses: siner308/staqd/.github/workflows/staqd.yml@v1
+    uses: siner308/staqd/.github/workflows/staqd-command.yml@v1
 ```
 
-That's it. The reusable workflow handles everything internally: guide comments, base branch resolution, concurrency groups, and command execution.
+Each workflow triggers only on its relevant event, keeping PR checks clean and focused.
+
+Note: The single-file `staqd.yml` workflow still works for backward compatibility, but may show skipped jobs in branch protection checks.
 
 ### With GitHub App (recommended for CI auto-trigger)
 
 ```yaml
+# staqd-auto-detect.yml
 jobs:
   staqd:
-    uses: siner308/staqd/.github/workflows/staqd.yml@v1
+    uses: siner308/staqd/.github/workflows/staqd-auto-detect.yml@v1
+    with:
+      app-id: ${{ vars.STAQD_APP_ID }}
+    secrets:
+      app-private-key: ${{ secrets.STAQD_APP_PRIVATE_KEY }}
+
+# staqd-command.yml
+jobs:
+  staqd:
+    uses: siner308/staqd/.github/workflows/staqd-command.yml@v1
     with:
       app-id: ${{ vars.STAQD_APP_ID }}
     secrets:
@@ -47,6 +77,11 @@ Why a GitHub App? `GITHUB_TOKEN` pushes don't trigger other workflows (GitHub se
 
 ### Reusable Workflow Inputs
 
+`staqd-auto-detect.yml`:
+- `app-id`: GitHub App ID. Used with `app-private-key` to generate an installation token. (Optional)
+- `runs-on`: Runner label for all jobs. Default: `ubuntu-latest`. (Optional)
+
+`staqd-command.yml`:
 - `app-id`: GitHub App ID. Used with `app-private-key` to generate an installation token. (Optional)
 - `runs-on`: Runner label for all jobs. Default: `ubuntu-latest`. (Optional)
 - `timeout-minutes`: Timeout for command job. Default: `30`. (Optional)


### PR DESCRIPTION
resolves: #27 

  ## Summary                                                                      
                                                                                  
  • **Split reusable workflows by event** (staqd-auto-detect.yml + staqd-command.
  yml) to avoid skipped job marks in branch protection checks                     
  • **Remove false "One workflow file" tagline** from README, llms-full.txt,     
  landing page meta tags, and action.yml                                          
  • **Delete "Zero Setup Tax" feature section** (HTML + CSS + EN/KO i18n keys)   
  from landing page                                                               
  • **Replace backward-compat note** with clean deprecation notice for single-file
  staqd.yml                                                                       
  • **Make GitHub App examples complete** — full copy-pasteable YAML with name, on,
  permissions                                                                     
  • **Add dogfood comments** to dogfood-auto-detect.yml and dogfood-command.yml  
                                                                                  
  ## Test plan                                                                    
                                                                                  
  [ ] Search docs for "No CLI", "No SaaS", "one workflow file" → 0 results       
  [ ] Landing page renders without broken sections or console errors              
  [ ] README and llms-full.txt Quick Start + GitHub App sections are consistent   
  [ ] GitHub App YAML examples are complete and copy-pasteable                    
                                                                                  
  🤖 Generated with Claude Code https://claude.com/claude-code                    