### PR TITLE
feat: make restack recursive by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Comment on a PR to trigger:
 | `stack merge` (`st merge`) | Auto-discover stack, merge this PR, restack child branches, and delete the merged branch |
 | `stack merge-all` (`st merge-all`) | Auto-discover stack, merge the entire stack in order, deleting each branch after merge (all PRs must be approved) |
 | `stack merge-all --force` (`st merge-all --force`) | Same as `merge-all` but skips the approval check |
-| `stack restack` (`st restack`) | Rebase child branches without merging |
+| `stack restack` (`st restack`) | Restack entire stack recursively |
 | `stack discover` (`st discover`) | Auto-discover stack tree from base branches and update metadata |
 | `stack help` (`st help`) | Show usage |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -992,7 +992,7 @@
             <span class="command-badge command-badge-write">push</span>
             <a href="#cmd-restack" class="cmd-anchor" aria-label="Link to this command">#</a>
           </div>
-          <p class="command-desc" data-i18n="cmd.restack.desc">Rebase all direct child branches onto this PR's latest head. Use after pushing new commits to a parent PR.</p>
+          <p class="command-desc" data-i18n="cmd.restack.desc">Restack entire stack recursively — rebases all descendant branches in topological order. Use after pushing new commits to a parent PR.</p>
           <div class="command-details">
             <div class="command-detail-item">
               <span class="command-detail-label" data-i18n="common.whenToUse">When to use</span>
@@ -1000,7 +1000,7 @@
             </div>
             <div class="command-detail-item">
               <span class="command-detail-label" data-i18n="common.whatItDoes">What it does</span>
-              <span data-i18n-html="cmd.restack.what">Runs <code>git rebase --onto</code> for each child branch and force-pushes. Posts conflict resolution commands if rebase fails</span>
+              <span data-i18n-html="cmd.restack.what">Auto-discovers the stack, then runs <code>git rebase --onto</code> for each descendant branch in topological order. Stops recursing into subtrees on conflict and posts resolution commands</span>
             </div>
           </div>
         </div>
@@ -1222,9 +1222,9 @@ feat-2:              E'───F'   <span class="code-comment">(C, D removed; o
         'cmd.discover.when': "After creating stacked PRs, or when you re-target a PR's base branch to form a new stack",
         'cmd.discover.what': "Recursively finds child PRs via base branch, updates metadata in each PR body, and reports if any children need restacking",
 
-        'cmd.restack.desc': "Rebase all direct child branches onto this PR's latest head. Use after pushing new commits to a parent PR.",
+        'cmd.restack.desc': "Restack entire stack recursively — rebases all descendant branches in topological order. Use after pushing new commits to a parent PR.",
         'cmd.restack.when': 'After updating a parent PR with new commits, or when <code>st discover</code> shows ⚠️ indicators',
-        'cmd.restack.what': 'Runs <code>git rebase --onto</code> for each child branch and force-pushes. Posts conflict resolution commands if rebase fails',
+        'cmd.restack.what': 'Auto-discovers the stack, then runs <code>git rebase --onto</code> for each descendant branch in topological order. Stops recursing into subtrees on conflict and posts resolution commands',
 
         'cmd.merge.desc': 'Auto-discover the stack tree, merge this PR into its base branch, then automatically restack all child branches.',
         'cmd.merge.when': 'When this PR is approved and ready to merge, but child PRs still need more work',
@@ -1316,9 +1316,9 @@ feat-2:              E'───F'   <span class="code-comment">(C, D removed; o
         'cmd.discover.when': '스택 PR을 만든 후, 또는 PR의 베이스 브랜치를 변경하여 새로운 스택을 구성할 때 사용하세요',
         'cmd.discover.what': '베이스 브랜치를 따라 하위 PR을 재귀적으로 찾고, 각 PR 본문의 메타데이터를 업데이트하며, 리스택이 필요한 항목을 알려줍니다',
 
-        'cmd.restack.desc': '이 PR의 최신 head를 기준으로 모든 직계 하위 브랜치를 리베이스합니다. 상위 PR에 새 커밋을 푸시한 후 사용하세요.',
+        'cmd.restack.desc': '전체 스택을 재귀적으로 리스택합니다 — 모든 하위 브랜치를 위상 순서대로 리베이스합니다. 상위 PR에 새 커밋을 푸시한 후 사용하세요.',
         'cmd.restack.when': '상위 PR에 새 커밋을 추가한 후, 또는 <code>st discover</code>에서 ⚠️ 표시가 나타날 때 사용하세요',
-        'cmd.restack.what': '각 하위 브랜치에 <code>git rebase --onto</code>를 실행하고 강제 푸시합니다. 리베이스 실패 시 충돌 해결 명령어를 안내합니다',
+        'cmd.restack.what': '스택을 자동 탐색한 후 모든 하위 브랜치에 위상 순서대로 <code>git rebase --onto</code>를 실행합니다. 충돌 시 해당 서브트리 탐색을 중단하고 해결 명령어를 안내합니다',
 
         'cmd.merge.desc': '스택 트리를 자동 탐색한 후, 이 PR을 베이스 브랜치에 머지하고 모든 하위 브랜치를 자동으로 리스택합니다.',
         'cmd.merge.when': '이 PR이 승인되어 머지할 준비가 됐지만, 하위 PR은 아직 작업이 필요할 때 사용하세요',

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -122,7 +122,7 @@ Comment on a PR to trigger:
 - `stack merge` (`st merge`) — Auto-discover stack, merge this PR, restack child branches, and delete the merged branch
 - `stack merge-all` (`st merge-all`) — Auto-discover stack, merge the entire stack in order, deleting each branch after merge (all PRs must be approved)
 - `stack merge-all --force` (`st merge-all --force`) — Same as `merge-all` but skips the approval check
-- `stack restack` (`st restack`) — Rebase child branches without merging
+- `stack restack` (`st restack`) — Restack entire stack recursively
 - `stack discover` (`st discover`) — Auto-discover stack tree from base branches and update metadata
 - `stack help` (`st help`) — Show usage
 
@@ -137,10 +137,10 @@ Auto-detect the stack tree by scanning open PRs' base branch relationships. No m
 
 ### stack restack
 
-Rebase all direct child branches onto this PR's latest head. Use after pushing new commits to a parent PR.
+Restack entire stack recursively — rebases all descendant branches in topological order. Use after pushing new commits to a parent PR.
 
 - When to use: After updating a parent PR with new commits, or when `st discover` shows warning indicators.
-- What it does: Runs `git rebase --onto` for each child branch and force-pushes. Posts conflict resolution commands if rebase fails.
+- What it does: Auto-discovers the stack, then runs `git rebase --onto` for each descendant branch in topological order. Stops recursing into subtrees on conflict and posts resolution commands.
 
 ### stack merge
 

--- a/src/command.js
+++ b/src/command.js
@@ -405,13 +405,15 @@ module.exports = async function command({ github, context, core, exec, command, 
 
       // Recursive restack: process tree in topological order (parent before children)
       const allResults = [];
+      const visited = new Set();
 
       async function recursiveRestack(parentPrNum, parentBranch, parentSkipSha) {
+        if (visited.has(parentPrNum)) return;
+        visited.add(parentPrNum);
+
         const { meta: pMeta } = await getStackMeta(parentPrNum);
         const pChildren = pMeta?.children || [];
         if (!pChildren.length) return;
-
-        await exec.exec('git', ['fetch', 'origin']);
 
         for (const child of pChildren) {
           const oldTip = await getOldTip(child.branch);
@@ -425,6 +427,7 @@ module.exports = async function command({ github, context, core, exec, command, 
 
           if (r.ok) {
             allResults.push({ ...child, status: 'restacked', oldTip, parent: parentBranch });
+            await exec.exec('git', ['fetch', 'origin']);
             // Recursively restack this child's children, using old tip as skip sha
             await recursiveRestack(child.pr, child.branch, oldTip);
           } else {
@@ -436,12 +439,40 @@ module.exports = async function command({ github, context, core, exec, command, 
         }
       }
 
+      await exec.exec('git', ['fetch', 'origin']);
       await recursiveRestack(prNumber, freshPr.head.ref, freshPr.head.sha);
 
       const ok = allResults.every(r => r.status === 'restacked');
+      const label = { restacked: 'Restacked', conflict: 'Conflict', missing: 'Branch not found' };
       const rows = allResults.map(
-        r => `| \`${r.branch}\` | #${r.pr} | ${r.status === 'restacked' ? 'Restacked' : r.status === 'conflict' ? 'Conflict' : r.status === 'missing' ? 'Branch not found' : r.status} | \`${r.parent}\` |`
+        r => `| \`${r.branch}\` | #${r.pr} | ${label[r.status] || r.status} | \`${r.parent}\` |`
       );
+
+      const conflicting = allResults.filter(r => r.status === 'conflict' && r.oldTip);
+      let manual = '';
+      if (conflicting.length) {
+        const cmds = ['git fetch origin', ''];
+        for (const r of conflicting) {
+          cmds.push(`# ${r.branch} (PR #${r.pr})`);
+          cmds.push(
+            `git rebase --onto origin/${r.parent} ${r.oldTip.substring(0, 8)} ${r.branch}`
+          );
+          cmds.push('# resolve conflicts if any, then:');
+          cmds.push(
+            `git push --force-with-lease origin ${r.branch}`
+          );
+          cmds.push('');
+        }
+        manual = [
+          '',
+          '<details><summary>Manual restack commands</summary>',
+          '',
+          '```bash',
+          ...cmds,
+          '```',
+          '</details>',
+        ].join('\n');
+      }
 
       await post(prNumber, [
         ok ? '### Restack: Complete' : '### Restack: Action Needed',
@@ -451,6 +482,7 @@ module.exports = async function command({ github, context, core, exec, command, 
         '| Branch | PR | Status | Parent |',
         '|--------|-----|--------|--------|',
         ...rows,
+        manual,
         ...(ok ? [] : ['', '> ⚠️ Some branches had conflicts. Fix conflicts and re-run `st restack`.']),
       ].join('\n'));
 

--- a/src/command.js
+++ b/src/command.js
@@ -1,5 +1,5 @@
 // Execute stack commands (help, restack, merge, merge-all).
-module.exports = async function command({ github, context, core, exec, command, force }) {
+module.exports = async function command({ github, context, core, exec, command, force, recursive = true }) {
   const { owner, repo } = context.repo;
   const prNumber = context.payload.issue.number;
 
@@ -382,7 +382,7 @@ module.exports = async function command({ github, context, core, exec, command, 
       '| `stack merge` (`st merge`) | Merge this PR, restack children |',
       '| `stack merge-all` (`st merge-all`) | Merge entire stack (requires approval) |',
       '| `stack merge-all --force` (`st merge-all --force`) | Skip approval check |',
-      '| `stack restack` (`st restack`) | Restack children only |',
+      '| `stack restack` (`st restack`) | Restack entire stack recursively |',
       '| `stack discover` (`st discover`) | Auto-discover stack tree from base branches |',
       '',
       `**Stack:** ${stack}`,
@@ -392,6 +392,73 @@ module.exports = async function command({ github, context, core, exec, command, 
 
   // ── restack ──
   if (command === 'restack') {
+    if (recursive) {
+      // Discover full stack tree first to ensure metadata is fresh
+      await runDiscover(prNumber);
+      const { meta: freshMeta, pr: freshPr } = await getStackMeta(prNumber);
+      const freshChildren = freshMeta?.children || [];
+
+      if (!freshChildren.length) {
+        await post(prNumber, 'No children to restack.');
+        return;
+      }
+
+      // Recursive restack: process tree in topological order (parent before children)
+      const allResults = [];
+
+      async function recursiveRestack(parentPrNum, parentBranch, parentSkipSha) {
+        const { meta: pMeta } = await getStackMeta(parentPrNum);
+        const pChildren = pMeta?.children || [];
+        if (!pChildren.length) return;
+
+        await exec.exec('git', ['fetch', 'origin']);
+
+        for (const child of pChildren) {
+          const oldTip = await getOldTip(child.branch);
+          if (!oldTip) {
+            allResults.push({ ...child, status: 'missing', parent: parentBranch });
+            continue;
+          }
+
+          await ensureLocalBranch(child.branch);
+          const r = await doRestack(child.branch, `origin/${parentBranch}`, parentSkipSha);
+
+          if (r.ok) {
+            allResults.push({ ...child, status: 'restacked', oldTip, parent: parentBranch });
+            // Recursively restack this child's children, using old tip as skip sha
+            await recursiveRestack(child.pr, child.branch, oldTip);
+          } else {
+            allResults.push({
+              ...child, status: 'conflict', oldTip, error: r.error, parent: parentBranch,
+            });
+            // Stop recursing into this subtree on conflict to avoid cascading failures
+          }
+        }
+      }
+
+      await recursiveRestack(prNumber, freshPr.head.ref, freshPr.head.sha);
+
+      const ok = allResults.every(r => r.status === 'restacked');
+      const rows = allResults.map(
+        r => `| \`${r.branch}\` | #${r.pr} | ${r.status === 'restacked' ? 'Restacked' : r.status === 'conflict' ? 'Conflict' : r.status === 'missing' ? 'Branch not found' : r.status} | \`${r.parent}\` |`
+      );
+
+      await post(prNumber, [
+        ok ? '### Restack: Complete' : '### Restack: Action Needed',
+        '',
+        `Restacked **${allResults.filter(r => r.status === 'restacked').length}/${allResults.length}** branch(es) across the stack.`,
+        '',
+        '| Branch | PR | Status | Parent |',
+        '|--------|-----|--------|--------|',
+        ...rows,
+        ...(ok ? [] : ['', '> ⚠️ Some branches had conflicts. Fix conflicts and re-run `st restack`.']),
+      ].join('\n'));
+
+      if (!ok) core.setFailed('Restack had failures');
+      return;
+    }
+
+    // Non-recursive: restack direct children only
     if (!children.length) {
       await post(prNumber, 'No children to restack.');
       return;

--- a/src/guide.js
+++ b/src/guide.js
@@ -40,7 +40,7 @@ module.exports = async function guide({ github, context }) {
     '| `stack merge` (`st merge`) | Merge this PR, restack children |',
     '| `stack merge-all` (`st merge-all`) | Merge entire stack (requires all approved) |',
     '| `stack merge-all --force` (`st merge-all --force`) | Merge entire stack (skip approval check) |',
-    '| `stack restack` (`st restack`) | Restack children without merging |',
+    '| `stack restack` (`st restack`) | Restack entire stack recursively |',
     '| `stack discover` (`st discover`) | Auto-discover stack tree from base branches |',
     '',
     `**Stack:** ${stack}`,


### PR DESCRIPTION

  ## Summary                                                                      
                                                                                  
  • st restack now auto-discovers the full stack tree and rebases **all descendant
  branches** in topological order (not just direct children)                      
  • The recursive parameter defaults to true; can be passed as false for the     
  original shallow behavior                                                       
  • Stops recursing into subtrees on conflict to avoid cascading failures        
                                                                                  
  ## Changes                                                                      
                                                                                  
  File              │What                                                         
  ──────────────────┼─────────────────────────────────────────────────────────────
  src/command.js    │Added recursive = true param, recursive restack logic with r…
  src/guide.js      │Updated command description                                  
  README.md         │Updated command table                                        
  docs/index.html   │Updated EN/KO descriptions                                   
  docs/llms-full.txt│Updated LLM-facing docs                                      
                                                                                  
  ## Test plan                                                                    
                                                                                  
  [ ] st restack on a PR with children → restacks all descendants recursively    
  [ ] st restack on a PR with no children → posts "No children to restack"       
  [ ] Conflict in middle of stack → stops recursing into that subtree, reports   
  partial results                                                                 
  [ ] st merge / st merge-all still work as before (unaffected)                   
                                                                                  
  Closes #29                                                                      
                                                                                  
  🤖 Generated with Claude Code https://claude.com/claude-code                    