### PR TITLE
feat: auto-restack children when parent is merged via GitHub UI

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -550,6 +550,67 @@ module.exports = async function command({ github, context, core, exec, command, 
 
   // ── restack ──
   if (command === 'restack') {
+    // Orphan rebase: if the parent was merged via GitHub UI (not st merge),
+    // orphan.js embeds <!-- orphan-rebase:{"parentHeadSha":"..."} --> in a
+    // comment.  The parentHeadSha marks where the child's own commits begin,
+    // allowing us to rebase the child itself onto its (new) base branch,
+    // stripping the already-squash-merged parent commits.
+    const orphanPat = /<!-- orphan-rebase:([\s\S]*?) -->/;
+    let selfRebased = false;
+    {
+      const { data: prComments } = await github.rest.issues.listComments({
+        owner, repo, issue_number: prNumber,
+      });
+      // Find the most recent orphan-rebase metadata
+      let orphanMeta = null;
+      for (const c of prComments) {
+        const om = (c.body || '').match(orphanPat);
+        if (om) {
+          try { orphanMeta = JSON.parse(om[1]); } catch {}
+        }
+      }
+      if (orphanMeta?.parentHeadSha) {
+        const { data: thisPr } = await github.rest.pulls.get({
+          owner, repo, pull_number: prNumber,
+        });
+        await exec.exec('git', ['fetch', 'origin']);
+        await ensureLocalBranch(thisPr.head.ref);
+        const r = await doRestack(
+          thisPr.head.ref, `origin/${thisPr.base.ref}`, orphanMeta.parentHeadSha
+        );
+        if (r.ok) {
+          selfRebased = true;
+          await exec.exec('git', ['fetch', 'origin']);
+          // Clean up: delete the orphan-rebase comment to prevent re-runs
+          for (const c of prComments) {
+            if (orphanPat.test(c.body || '')) {
+              await github.rest.issues.deleteComment({
+                owner, repo, comment_id: c.id,
+              }).catch(() => {});
+            }
+          }
+        } else {
+          await post(prNumber, [
+            '### Restack: Action Needed',
+            '',
+            `Failed to rebase \`${thisPr.head.ref}\` onto \`${thisPr.base.ref}\` after parent merge.`,
+            '',
+            '<details><summary>Manual restack command</summary>',
+            '',
+            '```bash',
+            'git fetch origin',
+            `git rebase --onto origin/${thisPr.base.ref} ${orphanMeta.parentHeadSha.substring(0, 8)} ${thisPr.head.ref}`,
+            '# resolve conflicts, then:',
+            `git push --force-with-lease origin ${thisPr.head.ref}`,
+            '```',
+            '</details>',
+          ].join('\n'));
+          core.setFailed('Orphan rebase had conflicts');
+          return;
+        }
+      }
+    }
+
     if (recursive) {
       // Discover full stack tree first to ensure metadata is fresh
       await runDiscover(prNumber);
@@ -557,7 +618,15 @@ module.exports = async function command({ github, context, core, exec, command, 
       const freshChildren = freshMeta?.children || [];
 
       if (!freshChildren.length) {
-        await post(prNumber, 'No children to restack.');
+        if (selfRebased) {
+          await post(prNumber, [
+            '### Restack: Complete',
+            '',
+            `Rebased \`${freshPr.head.ref}\` onto \`${freshPr.base.ref}\` after parent merge.`,
+          ].join('\n'));
+        } else {
+          await post(prNumber, 'No children to restack.');
+        }
         return;
       }
 
@@ -635,6 +704,9 @@ module.exports = async function command({ github, context, core, exec, command, 
       await post(prNumber, [
         ok ? '### Restack: Complete' : '### Restack: Action Needed',
         '',
+        ...(selfRebased
+          ? [`Rebased \`${freshPr.head.ref}\` onto \`${freshPr.base.ref}\` after parent merge.`, '']
+          : []),
         `Restacked **${allResults.filter(r => r.status === 'restacked').length}/${allResults.length}** branch(es) across the stack.`,
         '',
         '| Branch | PR | Status | Parent |',
@@ -650,7 +722,15 @@ module.exports = async function command({ github, context, core, exec, command, 
 
     // Non-recursive: restack direct children only
     if (!children.length) {
-      await post(prNumber, 'No children to restack.');
+      if (selfRebased) {
+        await post(prNumber, [
+          '### Restack: Complete',
+          '',
+          `Rebased \`${pr.head.ref}\` onto \`${baseBranch}\` after parent merge.`,
+        ].join('\n'));
+      } else {
+        await post(prNumber, 'No children to restack.');
+      }
       return;
     }
 

--- a/src/orphan.js
+++ b/src/orphan.js
@@ -25,9 +25,18 @@ module.exports = async function orphan({ github, context }) {
         body: [
           `#${pr.number} (\`${pr.head.ref}\`) was merged.`,
           `Base branch updated to \`${baseBranch}\`.`,
-          '',
-          'Run `st restack` if your branch needs rebasing.',
         ].join('\n'),
+      })
+      .catch(() => {});
+
+    // Post `st restack` command to trigger the command workflow.
+    // With a GitHub App token this fires an issue_comment event that
+    // auto-restacks the child.  With GITHUB_TOKEN the event won't fire
+    // (GitHub limitation), but the comment remains as a manual hint.
+    await github.rest.issues
+      .createComment({
+        owner, repo, issue_number: child.pr,
+        body: 'st restack',
       })
       .catch(() => {});
   }

--- a/src/orphan.js
+++ b/src/orphan.js
@@ -15,9 +15,41 @@ module.exports = async function orphan({ github, context }) {
   const baseBranch = pr.base.ref;
 
   for (const child of meta.children) {
-    await github.rest.pulls
+    // Validate: pr number must be a positive integer.
+    if (!Number.isInteger(child.pr) || child.pr <= 0) continue;
+
+    // Validate: child PR must be open and its base must match the merged
+    // PR's head branch (guards against stale or tampered metadata).
+    let childPr;
+    try {
+      ({ data: childPr } = await github.rest.pulls.get({
+        owner, repo, pull_number: child.pr,
+      }));
+    } catch {
+      continue;
+    }
+    if (childPr.state !== 'open') continue;
+    if (childPr.base.ref !== pr.head.ref) continue;
+
+    // Update child's base branch to the merged PR's base (e.g. main).
+    const updated = await github.rest.pulls
       .update({ owner, repo, pull_number: child.pr, base: baseBranch })
-      .catch(() => {});
+      .then(() => true)
+      .catch(() => false);
+
+    if (!updated) {
+      await github.rest.issues
+        .createComment({
+          owner, repo, issue_number: child.pr,
+          body: [
+            `#${pr.number} (\`${pr.head.ref}\`) was merged.`,
+            `Failed to update base branch to \`${baseBranch}\`.`,
+            'Run `st restack` manually if your branch needs rebasing.',
+          ].join('\n'),
+        })
+        .catch(() => {});
+      continue;
+    }
 
     await github.rest.issues
       .createComment({
@@ -25,14 +57,20 @@ module.exports = async function orphan({ github, context }) {
         body: [
           `#${pr.number} (\`${pr.head.ref}\`) was merged.`,
           `Base branch updated to \`${baseBranch}\`.`,
+          '',
+          'Auto-restack will be attempted shortly.',
+          'If it does not trigger, run `st restack` manually.',
         ].join('\n'),
       })
       .catch(() => {});
 
     // Post `st restack` command to trigger the command workflow.
+    // Must match the regex in action.yml Parse command step:
+    //   /^(?:stack|st)\s+(merge-all|merge|restack|discover|help)\b(.*)$/i
     // With a GitHub App token this fires an issue_comment event that
     // auto-restacks the child.  With GITHUB_TOKEN the event won't fire
-    // (GitHub limitation), but the comment remains as a manual hint.
+    // (GitHub Actions limitation), but the notification above tells the
+    // user to run it manually.
     await github.rest.issues
       .createComment({
         owner, repo, issue_number: child.pr,

--- a/src/orphan.js
+++ b/src/orphan.js
@@ -51,6 +51,12 @@ module.exports = async function orphan({ github, context }) {
       continue;
     }
 
+    // Embed parent's head SHA so the restack command knows where to
+    // split the child's own commits from the (now squash-merged) parent.
+    // Without this, `st restack` cannot rebase the child itself — it
+    // only restacks the child's children.
+    const orphanMeta = JSON.stringify({ parentHeadSha: pr.head.sha });
+
     await github.rest.issues
       .createComment({
         owner, repo, issue_number: child.pr,
@@ -60,6 +66,8 @@ module.exports = async function orphan({ github, context }) {
           '',
           'Auto-restack will be attempted shortly.',
           'If it does not trigger, run `st restack` manually.',
+          '',
+          `<!-- orphan-rebase:${orphanMeta} -->`,
         ].join('\n'),
       })
       .catch(() => {});


### PR DESCRIPTION

  ## Summary                                                                      
                                                                                  
  • When a parent PR is squash-merged via the GitHub UI, orphan.js now posts a st
  restack command comment on each child PR                                        
  • With a GitHub App token, this automatically triggers the command workflow to 
  rebase the child branch, keeping its diff clean                                 
  • With GITHUB_TOKEN (GitHub limitation), the event won't auto-fire but the     
  comment remains as a manual hint                                                
                                                                                  
  ## How it works                                                                 
                                                                                  
  Before (current behavior):                                                      
                                                                                  
  1. Parent merged via GitHub UI → orphan.js updates child's base branch ✅      
  2. Child's branch is NOT rebased ❌ → diff accumulates parent's commits        
                                                                                  
  After (this PR):                                                                
                                                                                  
  1. Parent merged via GitHub UI → orphan.js updates child's base branch ✅      
  2. orphan.js posts st restack on child PR → command workflow triggers → child is
  rebased ✅                                                                      
                                                                                  
  ## Note                                                                         
                                                                                  
  Auto-trigger requires a **GitHub App token** (not GITHUB_TOKEN). This is because
  GitHub Actions does not fire issue_comment events for comments created with     
  GITHUB_TOKEN to prevent infinite loops. Users already using a GitHub App        
  (recommended for CI auto-trigger after force push) get this for free.           
                                                                                  
  Closes #33                                                                      
                                                                                  
  ## Test plan                                                                    
                                                                                  
  [ ] Set up a stack: main ← PR#1 ← PR#2                                        
  [ ] Squash-merge PR#1 via GitHub UI                                             
  [ ] Verify orphan.js posts notification + st restack comments on PR#2           
  [ ] Verify st restack triggers the command workflow (with GitHub App token)     
  [ ] Verify PR#2's diff only shows its own changes after restack                 
                                                                                  
  🤖 Generated with Claude Code https://claude.com/claude-code                    