### PR TITLE
feat: add local CLI (st) for sync, restack, submit, move

### DIFF
--- a/.claude/commands/dev-guide.md
+++ b/.claude/commands/dev-guide.md
@@ -1,0 +1,44 @@
+# staqd Development Guide
+
+You are helping develop **staqd**, a GitHub Actions-based stacked PR merge queue tool.
+
+## Context
+
+Read the following files to understand the current state:
+- `src/command.js` — core command logic (~1050 lines)
+- `src/guide.js` — stack guide comment bot
+- `src/orphan.js` — orphan child PR handler
+- `action.yml` — composite action entry point
+- `README.md` — user-facing documentation
+
+## Architecture Constraints
+
+- **Runtime**: GitHub Actions `actions/github-script@v7` — code receives `{ github, context, core, exec }` objects
+- **No npm**: No `package.json`, no external dependencies. Only GitHub Actions toolkit utilities.
+- **No build step**: Plain JavaScript (ES2020+), changes to `src/*.js` are immediately effective.
+- **API calls**: Use `github.rest.*` (Octokit REST). Do NOT use raw `fetch` or `node-fetch`.
+- **Git operations**: Use `exec.exec()` and `exec.getExecOutput()` from `@actions/exec`. Do NOT use `child_process`.
+- **Metadata**: Stored as `<!-- stack-rebase:{...} -->` HTML comments in PR body (with comment fallback).
+
+## Key Patterns
+
+1. **Rebase primitive**: `git rebase --onto <new_base> <skip_sha> <child_branch>` + `--force-with-lease` push
+2. **Tree traversal**: DFS with `getStackMeta()` → `children` → recurse
+3. **Pre-compute merge-bases**: Before any rebase in `merge-all`, compute all merge-bases while history is intact
+4. **2-phase merge**: Pre-restack children onto parent HEAD → squash-merge → restack children onto main
+5. **Retry pattern**: `tryMerge()` retries 30s × 20 for CI status checks
+
+## Testing
+
+No test framework exists. Changes are tested via:
+1. Push to a branch and trigger via PR comments on a real repo
+2. Dogfood workflows in `.github/workflows/dogfood-*.yml`
+3. Manual verification of PR comments and branch states
+
+## When making changes
+
+- Keep functions within `src/command.js` unless a clear separation concern exists (like `guide.js` and `orphan.js`)
+- Always post user-facing error messages as PR comments with actionable fix instructions
+- Include manual rebase commands in conflict reports
+- Maintain idempotency — commands should be safe to retry
+- Update `README.md`, `docs/llms-full.txt`, and `docs/llms.txt` if behavior changes (use `/sync-docs` to verify)

--- a/.claude/commands/dev-guide.md
+++ b/.claude/commands/dev-guide.md
@@ -1,24 +1,43 @@
 # staqd Development Guide
 
-You are helping develop **staqd**, a GitHub Actions-based stacked PR merge queue tool.
+You are helping develop **staqd**, a stacked PR tool with two components: a GitHub Action and a local CLI (`st`).
 
 ## Context
 
-Read the following files to understand the current state:
+Read the relevant files before making changes:
+
+**Action** (`src/`):
 - `src/command.js` — core command logic (~1050 lines)
 - `src/guide.js` — stack guide comment bot
 - `src/orphan.js` — orphan child PR handler
 - `action.yml` — composite action entry point
-- `README.md` — user-facing documentation
+
+**CLI** (`cli/`):
+- `bin/st.mjs` — entry point, registered as `st` via `package.json` bin field
+- `cli/index.mjs` — command dispatcher and flag parser
+- `cli/git.mjs` — git and `gh` CLI wrappers (uses `execFileSync` with arg arrays for safety)
+- `cli/stack.mjs` — stack tree discovery from `gh pr list`
+- `cli/commands/` — one file per command: `sync.mjs`, `restack.mjs`, `submit.mjs`, `move.mjs`
+
+**Docs**: `README.md`, `docs/llms-full.txt`, `docs/llms.txt`
 
 ## Architecture Constraints
 
+### Action (`src/`)
 - **Runtime**: GitHub Actions `actions/github-script@v7` — code receives `{ github, context, core, exec }` objects
-- **No npm**: No `package.json`, no external dependencies. Only GitHub Actions toolkit utilities.
-- **No build step**: Plain JavaScript (ES2020+), changes to `src/*.js` are immediately effective.
 - **API calls**: Use `github.rest.*` (Octokit REST). Do NOT use raw `fetch` or `node-fetch`.
 - **Git operations**: Use `exec.exec()` and `exec.getExecOutput()` from `@actions/exec`. Do NOT use `child_process`.
 - **Metadata**: Stored as `<!-- stack-rebase:{...} -->` HTML comments in PR body (with comment fallback).
+
+### CLI (`cli/`)
+- **Runtime**: Node.js ESM modules, invoked via `node bin/st.mjs <command>` or `npx staqd <command>`
+- **Git/GitHub**: Uses `child_process.execFileSync` with argument arrays (not string interpolation — prevents shell injection). Uses `gh` CLI for GitHub API calls (not Octokit).
+- **Flags**: All commands support `--dry-run`. Parse flags in `cli/index.mjs`.
+
+### Shared
+- **No external npm dependencies** at runtime. `devDependencies` (ESLint) are for development only.
+- **No build step**: Plain JavaScript (ES2020+), changes are immediately effective.
+- **Linting**: `pnpm run lint` runs ESLint with `eslint-plugin-security` rules. Run before committing.
 
 ## Key Patterns
 
@@ -27,18 +46,19 @@ Read the following files to understand the current state:
 3. **Pre-compute merge-bases**: Before any rebase in `merge-all`, compute all merge-bases while history is intact
 4. **2-phase merge**: Pre-restack children onto parent HEAD → squash-merge → restack children onto main
 5. **Retry pattern**: `tryMerge()` retries 30s × 20 for CI status checks
+6. **Shell safety**: CLI uses `execFileSync` with argument arrays — never construct shell commands via string interpolation
 
 ## Testing
 
-No test framework exists. Changes are tested via:
-1. Push to a branch and trigger via PR comments on a real repo
-2. Dogfood workflows in `.github/workflows/dogfood-*.yml`
-3. Manual verification of PR comments and branch states
+- **Linting**: `pnpm run lint` — must pass (ESLint with security rules)
+- **Action**: Push to a branch and trigger via PR comments. Dogfood workflows in `.github/workflows/dogfood-*.yml`.
+- **CLI**: `node bin/st.mjs <command>` locally. Requires `git` and `gh` CLI installed and authenticated.
 
 ## When making changes
 
-- Keep functions within `src/command.js` unless a clear separation concern exists (like `guide.js` and `orphan.js`)
+- Keep functions within `src/command.js` unless a clear separation concern exists
 - Always post user-facing error messages as PR comments with actionable fix instructions
 - Include manual rebase commands in conflict reports
 - Maintain idempotency — commands should be safe to retry
+- Run `pnpm run lint` before committing
 - Update `README.md`, `docs/llms-full.txt`, and `docs/llms.txt` if behavior changes (use `/sync-docs` to verify)

--- a/.claude/commands/sync-docs.md
+++ b/.claude/commands/sync-docs.md
@@ -1,23 +1,47 @@
 # sync-docs
 
-Review the current state of `src/command.js` and all documentation files (`README.md`, `docs/llms-full.txt`, `docs/llms.txt`) and identify any gaps or outdated content.
+Review the current state of all source files and documentation, then fix any gaps or outdated content.
+
+## Scope
+
+Compare the actual implementation against what the docs describe:
+
+**Source files to check**:
+- `src/command.js` — Action commands (`st merge`, `st merge-all`, `st restack`, `st discover`, `st help`)
+- `src/guide.js` — stack guide bot behavior
+- `src/orphan.js` — orphan child PR handling
+- `cli/index.mjs` — CLI command dispatcher and flags
+- `cli/commands/*.mjs` — CLI commands (`st sync`, `st restack`, `st submit`, `st move`)
+
+**Documentation files to update**:
+- `README.md` — user-facing docs (Action + CLI usage)
+- `docs/llms-full.txt` — detailed LLM-readable docs
+- `docs/llms.txt` — concise LLM-readable docs
+- `CLAUDE.md` — developer instructions for Claude Code
 
 ## What to check
 
-For each of the following areas, compare the actual implementation in `src/command.js` against what the docs describe:
-
-1. **Command behavior** — Does each command's description match what the code actually does?
-   - `st merge`: squash-merge, branch deletion, restack children
+1. **Action command behavior** — Does each command's description match what the code actually does?
+   - `st merge`: squash-merge, branch deletion, restack children, 2-phase pre-merge rebase
    - `st merge-all`: DFS order, branch deletion per PR, merge order table, failure guidance
-   - `st restack`: rebase children, conflict output
-   - `st discover`: tree output format (indented list, ⚠️ on stale nodes, no `→ child` suffix)
+   - `st restack`: rebase children, conflict output, recursive by default
+   - `st discover`: tree output format
    - `st help`: current output format
 
-2. **Output examples** — Are any hardcoded output examples in the docs out of sync with the actual output format in the code?
+2. **CLI command behavior** — Are CLI commands accurately documented?
+   - `st sync`: fetch + rebase onto main
+   - `st restack`: discover stack + rebase children
+   - `st submit`: create/update PRs
+   - `st move`: change base branch
+   - `--dry-run` flag behavior
 
-3. **New behaviors not yet documented** — Any code paths that have no corresponding documentation?
+3. **Output examples** — Are any hardcoded output examples in the docs out of sync with the actual output format?
 
-4. **Removed or changed behaviors** — Any docs that describe behavior that no longer exists in the code?
+4. **New behaviors not yet documented** — Any code paths that have no corresponding documentation?
+
+5. **Removed or changed behaviors** — Any docs that describe behavior that no longer exists?
+
+6. **CLAUDE.md accuracy** — Does it correctly describe the architecture, file layout, and conventions?
 
 ## What to produce
 
@@ -27,4 +51,4 @@ Output a clear report with:
 - **Needs update**: specific diffs — what the doc says vs what the code does, with file:line references
 - **Missing**: behaviors in code with no documentation
 
-Then apply all necessary updates to `README.md`, `docs/llms-full.txt`, and `docs/llms.txt`, keeping the writing style consistent with the existing English prose in each file.
+Then apply all necessary updates to the documentation files, keeping the writing style consistent with the existing prose in each file.

--- a/.claude/commands/test-action.md
+++ b/.claude/commands/test-action.md
@@ -1,30 +1,53 @@
-# Test staqd Action Changes
+# Test staqd Changes
 
-Guide for testing changes to staqd source code.
+Guide for testing changes to staqd source code (both Action and CLI).
 
-## Pre-flight checks
+## Step 1: Lint
 
-1. Read the changed files and verify:
+Run `pnpm run lint` first. Fix any errors before proceeding. Security warnings from `eslint-plugin-security` (like `detect-child-process`, `detect-non-literal-exec`) indicate potential shell injection — these must be addressed.
+
+## Step 2: Pre-flight code review
+
+### For Action changes (`src/`)
+
+1. Verify:
    - All `github.rest.*` calls use correct Octokit REST API signatures
    - All `exec.exec()` / `exec.getExecOutput()` calls have proper error handling
    - PR comments include actionable information for the developer
    - No `require()` of external packages (only relative `./` imports allowed)
 
 2. Trace the affected command path end-to-end:
-   - For `merge`: discover → preRestack → tryMerge → restackChildren → deleteBranch → post
-   - For `merge-all`: discover → computeMergeBases → preRestackTree → tryMerge root → mergeChildren (DFS) → post
-   - For `restack`: orphan check → discover → recursiveRestack (DFS) → post
-   - For `discover`: runDiscover (DFS) → updatePrMeta → post
+   - `merge`: discover → preRestack → tryMerge → restackChildren → deleteBranch → post
+   - `merge-all`: discover → computeMergeBases → preRestackTree → tryMerge root → mergeChildren (DFS) → post
+   - `restack`: orphan check → discover → recursiveRestack (DFS) → post
+   - `discover`: runDiscover (DFS) → updatePrMeta → post
 
-3. Check edge cases:
-   - No children (leaf PR)
-   - Single child (linear stack)
-   - Multiple children (tree/fan-out stack)
-   - Deleted/missing branches
-   - Conflict during rebase
-   - CI timeout during merge
+### For CLI changes (`cli/`)
 
-## Manual test procedure
+1. Verify:
+   - All shell calls use `execFileSync` with argument arrays (never string interpolation with `execSync`)
+   - `--dry-run` flag is respected (log the command but don't execute)
+   - Error messages are clear and include recovery steps
+   - No external npm runtime dependencies added
+
+2. Trace the affected command:
+   - `sync`: fetch → checkout main → pull → checkout original branch → rebase
+   - `restack`: discover stack → rebase children onto updated parent → force-push
+   - `submit`: create/update PR via `gh pr create`/`gh pr edit`
+   - `move`: update base branch reference → rebase
+
+## Step 3: Check edge cases
+
+- No children (leaf PR)
+- Single child (linear stack)
+- Multiple children (tree/fan-out stack)
+- Deleted/missing branches
+- Conflict during rebase
+- CI timeout during merge
+- Dirty working tree (CLI only)
+- No `gh` CLI authenticated (CLI only)
+
+## Step 4: Manual test — Action
 
 ```bash
 # 1. Create a test stack
@@ -45,12 +68,29 @@ git branch -D test-parent test-child 2>/dev/null
 git push origin --delete test-parent test-child 2>/dev/null
 ```
 
+## Step 5: Manual test — CLI
+
+```bash
+# Test each command with --dry-run first
+node bin/st.mjs sync --dry-run
+node bin/st.mjs restack --dry-run
+node bin/st.mjs submit --dry-run
+node bin/st.mjs move <target-branch> --dry-run
+
+# Then run for real on a test stack
+node bin/st.mjs sync
+node bin/st.mjs restack
+```
+
 ## What to verify
 
-- [ ] Bot reaction emojis appear (👀 → 🚀 or 😕)
+- [ ] `pnpm run lint` passes with no errors
+- [ ] Bot reaction emojis appear (👀 → 🚀 or 😕) for Action commands
 - [ ] Stack guide comment is posted/updated on PR open
 - [ ] `st discover` correctly identifies tree structure
 - [ ] `st restack` rebases children and reports status table
 - [ ] `st merge` pre-restacks, merges, restacks children, deletes branch
 - [ ] Conflict reports include manual fix commands
 - [ ] Child PRs get notification comments after parent merge
+- [ ] CLI `--dry-run` logs commands without executing
+- [ ] CLI handles missing `gh` auth gracefully

--- a/.claude/commands/test-action.md
+++ b/.claude/commands/test-action.md
@@ -1,0 +1,56 @@
+# Test staqd Action Changes
+
+Guide for testing changes to staqd source code.
+
+## Pre-flight checks
+
+1. Read the changed files and verify:
+   - All `github.rest.*` calls use correct Octokit REST API signatures
+   - All `exec.exec()` / `exec.getExecOutput()` calls have proper error handling
+   - PR comments include actionable information for the developer
+   - No `require()` of external packages (only relative `./` imports allowed)
+
+2. Trace the affected command path end-to-end:
+   - For `merge`: discover → preRestack → tryMerge → restackChildren → deleteBranch → post
+   - For `merge-all`: discover → computeMergeBases → preRestackTree → tryMerge root → mergeChildren (DFS) → post
+   - For `restack`: orphan check → discover → recursiveRestack (DFS) → post
+   - For `discover`: runDiscover (DFS) → updatePrMeta → post
+
+3. Check edge cases:
+   - No children (leaf PR)
+   - Single child (linear stack)
+   - Multiple children (tree/fan-out stack)
+   - Deleted/missing branches
+   - Conflict during rebase
+   - CI timeout during merge
+
+## Manual test procedure
+
+```bash
+# 1. Create a test stack
+git checkout main && git pull
+git checkout -b test-parent && echo "parent" > test.txt && git add . && git commit -m "parent" && git push -u origin test-parent
+git checkout -b test-child && echo "child" >> test.txt && git add . && git commit -m "child" && git push -u origin test-child
+
+# 2. Create PRs
+gh pr create --base main --head test-parent --title "test: parent"
+gh pr create --base test-parent --head test-child --title "test: child"
+
+# 3. Comment on parent PR to trigger commands
+# st discover → st restack → st merge (or st merge-all --force)
+
+# 4. Clean up after testing
+git checkout main
+git branch -D test-parent test-child 2>/dev/null
+git push origin --delete test-parent test-child 2>/dev/null
+```
+
+## What to verify
+
+- [ ] Bot reaction emojis appear (👀 → 🚀 or 😕)
+- [ ] Stack guide comment is posted/updated on PR open
+- [ ] `st discover` correctly identifies tree structure
+- [ ] `st restack` rebases children and reports status table
+- [ ] `st merge` pre-restacks, merges, restacks children, deletes branch
+- [ ] Conflict reports include manual fix commands
+- [ ] Child PRs get notification comments after parent merge

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Staqd (`/stakt/`) is a stacked PR tool with two components:
+1. **GitHub Action** — Composite action for managing stacked PRs via PR comment commands (`st merge`, `st restack`, `st discover`, `st merge-all`, `st help`)
+2. **CLI** (`st`) — Local CLI for syncing, restacking, submitting, and moving branches (`st sync`, `st restack`, `st submit`, `st move`)
+
+Written in plain JavaScript (ESM), no external npm dependencies. Distributed via `npx staqd` or `npm i -g staqd`.
+
+## Development
+
+No build step, no test framework. Changes to `src/*.js` and `cli/*.mjs` are effective immediately.
+
+- **Action code** (`src/`): Runs inside GitHub Actions using `actions/github-script@v7` which provides `github` (Octokit), `context`, `core`, and `exec` objects. Test by pushing to a branch and triggering via PR comments, or use the dogfood workflows in `.github/workflows/dogfood-*.yml`.
+- **CLI code** (`cli/`): ESM modules using `child_process.execSync` to call `git` and `gh` CLI. Test locally with `node bin/st.mjs <command>`. Requires `git` and `gh` CLI installed and authenticated.
+
+## Architecture
+
+### Entry Point
+- `action.yml` — Composite action definition. Dispatches between three code paths based on event type:
+  - `pull_request` events → `src/guide.js` (post/update stack guide) + `src/orphan.js` (handle merged parent)
+  - `issue_comment` events → parses `st <command>` from comment body → `src/command.js`
+
+### Source Files (all in `src/`)
+- **`command.js`** (~1050 lines) — Core logic for all five commands. Contains the rebase engine, merge orchestration, tree traversal, metadata management, and GitHub API interactions.
+- **`guide.js`** (~60 lines) — Posts/updates a bot comment on PRs listing available commands and current stack children.
+- **`orphan.js`** (~90 lines) — When a parent PR is merged via GitHub UI (not via `st merge`), retargets children to the parent's base branch and triggers auto-restack.
+
+### Metadata Storage
+Stack relationships are stored as HTML comments in PR bodies:
+```html
+<!-- stack-rebase:{"children":[{"branch":"feature-b","pr":42}]} -->
+```
+Falls back to searching issue comments if not found in PR body. No external database.
+
+### Key Algorithms in `command.js`
+- **`merge-all` uses 3 phases**: (0) pre-compute merge-bases for entire tree, (1) pre-restack tree recursively, (2) sequential DFS merge + restack
+- **`merge` uses 2 phases**: pre-merge rebase (to prevent file duplication in squash merge), then post-merge rebase of children onto main
+- **`doRestack()`**: Core rebase operation using `git rebase --onto <new_base> <skip_sha> <branch>` with `--force-with-lease` push
+- **`tryMerge()`**: Squash-merge with retry loop (30s × 20 attempts) waiting for CI status checks
+
+### Workflow Split
+Two separate workflows handle different GitHub events:
+- `staqd-auto-detect.yml` — `pull_request` events (opened, edited, closed)
+- `staqd-command.yml` — `issue_comment` events with concurrency control per base branch (`concurrency: staqd-${{ base-ref }}`)
+
+### Authentication
+Supports both `GITHUB_TOKEN` and GitHub App tokens (via `app-id` + `app-private-key` inputs). App tokens are needed to trigger CI workflows after force-push.
+
+### CLI (`cli/`)
+- **`bin/st.mjs`** — Entry point, registered as `st` via `package.json` `bin` field
+- **`cli/index.mjs`** — Command dispatcher and flag parser
+- **`cli/git.mjs`** — Git and `gh` CLI wrappers (no Octokit, uses `child_process.execSync`)
+- **`cli/stack.mjs`** — Stack tree discovery from PR list (`gh pr list` → build tree from base/head relationships)
+- **`cli/commands/`** — One file per command: `sync.mjs`, `restack.mjs`, `submit.mjs`, `move.mjs`
+
+## Code Conventions
+
+- Plain JavaScript (ES2020+), no TypeScript, no transpilation
+- No external npm dependencies
+- **Action** (`src/`): `exec.exec()` for git, `github.rest.*` (Octokit) for API, error messages posted as PR comments
+- **CLI** (`cli/`): ESM modules, `child_process.execSync` for `git`/`gh` CLI, colored terminal output with ANSI codes
+- Recursive tree operations use DFS traversal
+- `--dry-run` flag supported on all CLI commands

--- a/bin/st.mjs
+++ b/bin/st.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { run } from '../cli/index.mjs';
+
+run(process.argv.slice(2)).catch(err => {
+  console.error(`\x1b[31merror:\x1b[0m ${err.message}`);
+  process.exit(1);
+});

--- a/cli/commands/move.mjs
+++ b/cli/commands/move.mjs
@@ -1,0 +1,107 @@
+// st move <parent> — Move current branch to a new parent.
+
+import * as git from '../git.mjs';
+import { buildStackTree, printTree } from '../stack.mjs';
+
+export async function move(flags) {
+  const dryRun = flags['dry-run'];
+  const newParent = flags._[0];
+
+  if (!newParent) {
+    throw new Error('Usage: st move <parent-branch>');
+  }
+
+  const current = git.currentBranch();
+  if (!current) {
+    throw new Error('Not on a branch (detached HEAD).');
+  }
+
+  if (current === newParent) {
+    throw new Error('Cannot move a branch onto itself.');
+  }
+
+  if (!dryRun && !git.isClean()) {
+    throw new Error('Uncommitted changes detected. Commit or stash before running st move.');
+  }
+
+  console.log('Fetching origin...');
+  if (!dryRun) git.fetch();
+
+  // Verify new parent exists
+  const parentSha = git.remoteSha(newParent) || git.localSha(newParent);
+  if (!parentSha) {
+    throw new Error(`Branch "${newParent}" not found.`);
+  }
+
+  // Find old parent (current base branch from PR)
+  const prs = git.ghPrList();
+  const myPr = prs.find(p => p.headRefName === current);
+
+  if (!myPr) {
+    throw new Error(`No open PR found for branch "${current}". Run "st submit" first.`);
+  }
+
+  const oldParent = myPr.baseRefName;
+
+  if (oldParent === newParent) {
+    console.log(`Already based on ${newParent}.`);
+    return;
+  }
+
+  console.log(`Moving \x1b[1m${current}\x1b[0m: ${oldParent} → ${newParent}`);
+
+  // Compute merge-base with old parent
+  const mb = git.mergeBase(`origin/${oldParent}`, current);
+  if (!mb) {
+    throw new Error(`Cannot find merge-base between origin/${oldParent} and ${current}.`);
+  }
+
+  const newParentRef = git.remoteSha(newParent) ? `origin/${newParent}` : newParent;
+
+  if (dryRun) {
+    console.log(`  \x1b[33m~\x1b[0m Would rebase --onto ${newParentRef} ${mb.slice(0, 7)} ${current}`);
+    console.log(`  \x1b[33m~\x1b[0m Would update PR #${myPr.number} base to ${newParent}`);
+    return;
+  }
+
+  // Rebase onto new parent
+  const r = git.rebaseOnto(newParentRef, mb, current);
+  if (!r.ok) {
+    console.error('\n\x1b[31mConflict during rebase.\x1b[0m Resolve manually:');
+    console.log(`  git rebase --onto ${newParentRef} ${mb.slice(0, 7)} ${current}`);
+    console.log('  # resolve conflicts, then:');
+    console.log(`  git push --force-with-lease origin ${current}`);
+    console.log(`  gh pr edit ${myPr.number} --base ${newParent}`);
+    throw new Error('Rebase had conflicts.');
+  }
+
+  // Push and update PR
+  git.pushForce(current);
+  git.ghPrEditBase(myPr.number, newParent);
+
+  console.log(`  \x1b[32m✓\x1b[0m Rebased and pushed`);
+  console.log(`  \x1b[32m✓\x1b[0m PR #${myPr.number} base updated to ${newParent}`);
+
+  // Trigger discover to update metadata
+  const { roots } = buildStackTree(git.ghPrList());
+  const defBranch = git.defaultBranch();
+
+  // Find root PR of the stack to trigger discover
+  const rootPr = prs.find(p => p.baseRefName === defBranch && p.headRefName === newParent)
+    || prs.find(p => p.headRefName === newParent);
+
+  if (rootPr) {
+    console.log(`  Triggering discover on #${rootPr.number}...`);
+    git.ghPrComment(rootPr.number, 'st discover');
+  }
+
+  // Show updated tree
+  const freshPrs = git.ghPrList();
+  const { roots: freshRoots } = buildStackTree(freshPrs);
+  if (freshRoots.length) {
+    console.log('\n\x1b[1mStack:\x1b[0m');
+    for (const root of freshRoots) {
+      printTree(root);
+    }
+  }
+}

--- a/cli/commands/restack.mjs
+++ b/cli/commands/restack.mjs
@@ -63,13 +63,11 @@ export async function restack(flags) {
     }
 
     // Ensure local branch exists
-    git.exec(`git branch ${node.branch} origin/${node.branch} 2>/dev/null || true`, { silent: true });
+    git.ensureLocalBranch(node.branch);
 
     const r = git.rebaseOnto(parentRef, mb, node.branch);
     if (r.ok) {
       git.pushForce(node.branch);
-      // Re-fetch so subsequent children see updated refs
-      git.fetch();
       results.push({ branch: node.branch, pr: node.pr, status: 'restacked', parent: parent.branch });
     } else {
       results.push({ branch: node.branch, pr: node.pr, status: 'conflict', parent: parent.branch, error: r.error });

--- a/cli/commands/restack.mjs
+++ b/cli/commands/restack.mjs
@@ -1,0 +1,121 @@
+// st restack — Locally rebase stack branches onto their parents.
+
+import * as git from '../git.mjs';
+import { buildStackTree, findStackFor, walkDFS, printTree } from '../stack.mjs';
+
+export async function restack(flags) {
+  const dryRun = flags['dry-run'];
+
+  if (!dryRun && !git.isClean()) {
+    throw new Error('Uncommitted changes detected. Commit or stash before running st restack.');
+  }
+
+  const current = git.currentBranch();
+  if (!current) {
+    throw new Error('Not on a branch (detached HEAD).');
+  }
+
+  console.log('Fetching origin...');
+  if (!dryRun) git.fetch();
+
+  const prs = git.ghPrList();
+  const { roots, nodes } = buildStackTree(prs);
+  const stack = findStackFor(current, roots, nodes);
+
+  if (!stack) {
+    throw new Error(`Branch "${current}" is not part of any open PR stack.`);
+  }
+
+  // Pre-compute all merge-bases before any rebasing
+  const mergeBases = new Map();
+  walkDFS(stack, (node, parent) => {
+    if (!parent) return;
+    const mb = git.mergeBase(`origin/${parent.branch}`, `origin/${node.branch}`);
+    if (mb) mergeBases.set(node.branch, mb);
+  });
+
+  // DFS rebase: parent before children
+  const results = [];
+  const originalBranch = current;
+
+  walkDFS(stack, (node, parent) => {
+    if (!parent) return; // skip root
+
+    const mb = mergeBases.get(node.branch);
+    if (!mb) {
+      results.push({ branch: node.branch, pr: node.pr, status: 'no-merge-base' });
+      return;
+    }
+
+    const parentRef = `origin/${parent.branch}`;
+    const remoteChild = git.remoteSha(node.branch);
+    const parentSha = git.remoteSha(parent.branch);
+
+    // Check if restack is needed
+    if (remoteChild && mb === parentSha) {
+      results.push({ branch: node.branch, pr: node.pr, status: 'up-to-date' });
+      return;
+    }
+
+    if (dryRun) {
+      results.push({ branch: node.branch, pr: node.pr, status: 'would-restack', parent: parent.branch });
+      return;
+    }
+
+    // Ensure local branch exists
+    git.exec(`git branch ${node.branch} origin/${node.branch} 2>/dev/null || true`, { silent: true });
+
+    const r = git.rebaseOnto(parentRef, mb, node.branch);
+    if (r.ok) {
+      git.pushForce(node.branch);
+      // Re-fetch so subsequent children see updated refs
+      git.fetch();
+      results.push({ branch: node.branch, pr: node.pr, status: 'restacked', parent: parent.branch });
+    } else {
+      results.push({ branch: node.branch, pr: node.pr, status: 'conflict', parent: parent.branch, error: r.error });
+    }
+  });
+
+  // Restore original branch
+  if (!dryRun) {
+    try { git.checkout(originalBranch); } catch {}
+  }
+
+  // Print results
+  console.log('');
+  const icon = {
+    'restacked': '\x1b[32m✓\x1b[0m',
+    'would-restack': '\x1b[33m~\x1b[0m',
+    'up-to-date': '\x1b[90m·\x1b[0m',
+    'conflict': '\x1b[31m✗\x1b[0m',
+    'no-merge-base': '\x1b[31m?\x1b[0m',
+  };
+
+  for (const r of results) {
+    const i = icon[r.status] || ' ';
+    const parent = r.parent ? ` \x1b[90m← ${r.parent}\x1b[0m` : '';
+    console.log(`  ${i} \x1b[1m${r.branch}\x1b[0m \x1b[90m#${r.pr}\x1b[0m${parent}`);
+  }
+
+  const restacked = results.filter(r => r.status === 'restacked').length;
+  const conflicts = results.filter(r => r.status === 'conflict');
+
+  if (restacked) {
+    console.log(`\nRestacked ${restacked} branch(es).`);
+  }
+
+  if (conflicts.length) {
+    console.log('\n\x1b[31mConflicts:\x1b[0m');
+    for (const c of conflicts) {
+      console.log(`\n  # ${c.branch} (PR #${c.pr})`);
+      console.log(`  git rebase --onto origin/${c.parent} $(git merge-base origin/${c.parent} origin/${c.branch}) ${c.branch}`);
+      console.log(`  # resolve conflicts, then:`);
+      console.log(`  git push --force-with-lease origin ${c.branch}`);
+    }
+    throw new Error('Restack had conflicts.');
+  }
+
+  // Show stack
+  console.log('\n\x1b[1mStack:\x1b[0m');
+  printTree(stack);
+}

--- a/cli/commands/submit.mjs
+++ b/cli/commands/submit.mjs
@@ -14,7 +14,7 @@ export async function submit(flags) {
   // Push current branch first
   console.log(`Pushing ${current}...`);
   if (!dryRun) {
-    git.exec(`git push -u origin ${current}`);
+    git.pushUpstream(current);
   }
 
   // Discover stack from PRs
@@ -71,7 +71,7 @@ export async function submit(flags) {
       }
 
       try {
-        git.exec(`git push --force-with-lease origin ${node.branch}`);
+        git.pushForce(node.branch);
         results.push({ branch: node.branch, pr: node.pr, status: 'pushed' });
       } catch {
         results.push({ branch: node.branch, pr: node.pr, status: 'push-failed' });

--- a/cli/commands/submit.mjs
+++ b/cli/commands/submit.mjs
@@ -1,0 +1,160 @@
+// st submit — Push branches and create/update PRs.
+
+import * as git from '../git.mjs';
+import { buildStackTree, findStackFor, collectDFS, printTree } from '../stack.mjs';
+
+export async function submit(flags) {
+  const dryRun = flags['dry-run'];
+  const current = git.currentBranch();
+
+  if (!current) {
+    throw new Error('Not on a branch (detached HEAD).');
+  }
+
+  // Push current branch first
+  console.log(`Pushing ${current}...`);
+  if (!dryRun) {
+    git.exec(`git push -u origin ${current}`);
+  }
+
+  // Discover stack from PRs
+  const prs = git.ghPrList();
+  const { roots, nodes } = buildStackTree(prs);
+
+  // Check if current branch already has a PR
+  const existingPr = prs.find(p => p.headRefName === current);
+
+  if (!existingPr) {
+    // Need to create a PR — figure out the base branch
+    const base = detectBase(current, prs);
+
+    console.log(`Creating PR: ${current} → ${base}`);
+    if (!dryRun) {
+      // Generate title from branch name
+      const title = branchToTitle(current);
+      const url = git.ghPrCreate(current, base, title);
+      console.log(`  \x1b[32m✓\x1b[0m Created: ${url}`);
+    } else {
+      console.log(`  \x1b[33m~\x1b[0m Would create PR: ${current} → ${base}`);
+    }
+  } else {
+    console.log(`  \x1b[90m·\x1b[0m PR #${existingPr.number} already exists`);
+  }
+
+  // Re-fetch PR list after potential creation
+  const freshPrs = dryRun ? prs : git.ghPrList();
+  const { roots: freshRoots, nodes: freshNodes } = buildStackTree(freshPrs);
+
+  // Push all branches in the current stack
+  const stack = findStackFor(current, freshRoots, freshNodes);
+  if (stack) {
+    const allNodes = collectDFS(stack);
+    const results = [];
+
+    for (const node of allNodes) {
+      const local = git.localSha(node.branch);
+      const remote = git.remoteSha(node.branch);
+
+      if (!local) {
+        results.push({ branch: node.branch, pr: node.pr, status: 'no-local' });
+        continue;
+      }
+
+      if (local === remote) {
+        results.push({ branch: node.branch, pr: node.pr, status: 'up-to-date' });
+        continue;
+      }
+
+      if (dryRun) {
+        results.push({ branch: node.branch, pr: node.pr, status: 'would-push' });
+        continue;
+      }
+
+      try {
+        git.exec(`git push --force-with-lease origin ${node.branch}`);
+        results.push({ branch: node.branch, pr: node.pr, status: 'pushed' });
+      } catch {
+        results.push({ branch: node.branch, pr: node.pr, status: 'push-failed' });
+      }
+    }
+
+    // Update base branches if mismatched
+    for (const node of allNodes) {
+      const parentNode = findParent(node, stack);
+      if (!parentNode) continue;
+
+      const pr = freshPrs.find(p => p.number === node.pr);
+      if (pr && pr.baseRefName !== parentNode.branch) {
+        console.log(`  Updating #${node.pr} base: ${pr.baseRefName} → ${parentNode.branch}`);
+        if (!dryRun) {
+          git.ghPrEditBase(node.pr, parentNode.branch);
+        }
+      }
+    }
+
+    // Trigger discover on root PR
+    if (!dryRun) {
+      console.log(`\nTriggering discover on #${stack.pr}...`);
+      git.ghPrComment(stack.pr, 'st discover');
+    }
+
+    // Print results
+    console.log('');
+    const icon = {
+      'pushed': '\x1b[32m✓\x1b[0m',
+      'would-push': '\x1b[33m~\x1b[0m',
+      'up-to-date': '\x1b[90m·\x1b[0m',
+      'push-failed': '\x1b[31m✗\x1b[0m',
+      'no-local': '\x1b[90m-\x1b[0m',
+    };
+
+    for (const r of results) {
+      const i = icon[r.status] || ' ';
+      console.log(`  ${i} \x1b[1m${r.branch}\x1b[0m \x1b[90m#${r.pr}\x1b[0m ${r.status}`);
+    }
+
+    console.log('\n\x1b[1mStack:\x1b[0m');
+    printTree(stack);
+  }
+}
+
+/**
+ * Detect the base branch for a new PR.
+ * If any open PR's head is an ancestor of the current branch, use that as base.
+ * Otherwise, use the default branch.
+ */
+function detectBase(branch, prs) {
+  const defBranch = git.defaultBranch();
+
+  // Check if any PR branch is the parent (current branch was created from it)
+  for (const pr of prs) {
+    const mb = git.mergeBase(pr.headRefName, branch);
+    const prSha = git.localSha(pr.headRefName) || git.remoteSha(pr.headRefName);
+    if (mb && prSha && mb === prSha) {
+      return pr.headRefName;
+    }
+  }
+
+  return defBranch;
+}
+
+function findParent(node, root) {
+  if (root === node) return null;
+  for (const child of root.children) {
+    if (child === node) return root;
+    const found = findParent(node, child);
+    if (found) return found;
+  }
+  return null;
+}
+
+function branchToTitle(branch) {
+  // feat/auth-module → feat: auth module
+  // fix-login-bug → fix login bug
+  const parts = branch.replace(/[/_-]/g, ' ').trim().split(/\s+/);
+  const prefixes = ['feat', 'fix', 'chore', 'docs', 'refactor', 'test', 'ci'];
+  if (parts.length > 1 && prefixes.includes(parts[0])) {
+    return `${parts[0]}: ${parts.slice(1).join(' ')}`;
+  }
+  return parts.join(' ');
+}

--- a/cli/commands/submit.mjs
+++ b/cli/commands/submit.mjs
@@ -126,16 +126,24 @@ export async function submit(flags) {
 function detectBase(branch, prs) {
   const defBranch = git.defaultBranch();
 
-  // Check if any PR branch is the parent (current branch was created from it)
+  // Collect all PR branches that are ancestors of the current branch
+  let best = null;
+  let bestDistance = Infinity;
+
   for (const pr of prs) {
     const mb = git.mergeBase(pr.headRefName, branch);
     const prSha = git.localSha(pr.headRefName) || git.remoteSha(pr.headRefName);
     if (mb && prSha && mb === prSha) {
-      return pr.headRefName;
+      // Count commits between this ancestor and the branch to find the closest one
+      const distance = git.commitDistance(prSha, branch);
+      if (distance < bestDistance) {
+        best = pr.headRefName;
+        bestDistance = distance;
+      }
     }
   }
 
-  return defBranch;
+  return best || defBranch;
 }
 
 function findParent(node, root) {

--- a/cli/commands/sync.mjs
+++ b/cli/commands/sync.mjs
@@ -70,12 +70,8 @@ export async function sync(flags) {
         if (dryRun) {
           results.push({ branch, status: 'would-prune' });
         } else {
-          try {
-            git.exec(`git branch -D ${branch}`);
-            results.push({ branch, status: 'pruned' });
-          } catch {
-            results.push({ branch, status: 'prune-failed' });
-          }
+          const deleted = git.deleteBranch(branch);
+          results.push({ branch, status: deleted !== null ? 'pruned' : 'prune-failed' });
         }
       }
     }

--- a/cli/commands/sync.mjs
+++ b/cli/commands/sync.mjs
@@ -1,0 +1,120 @@
+// st sync — Sync local branches with remote after Actions restack.
+
+import * as git from '../git.mjs';
+import { buildStackTree, printTree } from '../stack.mjs';
+
+export async function sync(flags) {
+  const dryRun = flags['dry-run'];
+
+  console.log('Fetching origin...');
+  if (!dryRun) git.fetch();
+
+  const prs = git.ghPrList();
+  if (!prs.length) {
+    console.log('No open PRs found.');
+    return;
+  }
+
+  const { roots } = buildStackTree(prs);
+  const current = git.currentBranch();
+  const results = [];
+
+  for (const pr of prs) {
+    const branch = pr.headRefName;
+    const local = git.localSha(branch);
+    const remote = git.remoteSha(branch);
+
+    if (!local) {
+      results.push({ branch, pr: pr.number, status: 'no-local', detail: 'no local branch' });
+      continue;
+    }
+
+    if (!remote) {
+      results.push({ branch, pr: pr.number, status: 'pruned', detail: 'remote deleted' });
+      continue;
+    }
+
+    if (local === remote) {
+      results.push({ branch, pr: pr.number, status: 'up-to-date' });
+      continue;
+    }
+
+    // Local and remote differ — sync
+    if (dryRun) {
+      results.push({ branch, pr: pr.number, status: 'would-sync', detail: `${local.slice(0, 7)} → ${remote.slice(0, 7)}` });
+      continue;
+    }
+
+    if (branch === current) {
+      if (!git.isClean()) {
+        results.push({ branch, pr: pr.number, status: 'dirty', detail: 'uncommitted changes, skipped' });
+        continue;
+      }
+      git.resetHard(`origin/${branch}`);
+    } else {
+      git.branchForceUpdate(branch, `origin/${branch}`);
+    }
+
+    results.push({ branch, pr: pr.number, status: 'synced', detail: `${local.slice(0, 7)} → ${remote.slice(0, 7)}` });
+  }
+
+  // Prune: local branches whose remote tracking branch is gone (merged PRs)
+  if (flags.prune) {
+    const locals = git.localBranches();
+    const prBranches = new Set(prs.map(p => p.headRefName));
+    for (const branch of locals) {
+      if (branch === current || branch === git.defaultBranch()) continue;
+      if (prBranches.has(branch)) continue;
+      const remote = git.remoteSha(branch);
+      if (!remote) {
+        if (dryRun) {
+          results.push({ branch, status: 'would-prune' });
+        } else {
+          try {
+            git.exec(`git branch -D ${branch}`);
+            results.push({ branch, status: 'pruned' });
+          } catch {
+            results.push({ branch, status: 'prune-failed' });
+          }
+        }
+      }
+    }
+  }
+
+  // Print results
+  console.log('');
+  const icon = {
+    'synced': '\x1b[32m✓\x1b[0m',
+    'would-sync': '\x1b[33m~\x1b[0m',
+    'up-to-date': '\x1b[90m·\x1b[0m',
+    'dirty': '\x1b[31m✗\x1b[0m',
+    'pruned': '\x1b[33m✂\x1b[0m',
+    'would-prune': '\x1b[33m✂\x1b[0m',
+    'no-local': '\x1b[90m-\x1b[0m',
+    'prune-failed': '\x1b[31m✗\x1b[0m',
+  };
+
+  for (const r of results) {
+    const i = icon[r.status] || ' ';
+    const detail = r.detail ? ` \x1b[90m(${r.detail})\x1b[0m` : '';
+    const prLabel = r.pr ? ` \x1b[90m#${r.pr}\x1b[0m` : '';
+    console.log(`  ${i} \x1b[1m${r.branch}\x1b[0m${prLabel}${detail}`);
+  }
+
+  const synced = results.filter(r => r.status === 'synced').length;
+  const pruned = results.filter(r => r.status === 'pruned').length;
+  if (synced || pruned) {
+    const parts = [];
+    if (synced) parts.push(`synced ${synced}`);
+    if (pruned) parts.push(`pruned ${pruned}`);
+    console.log(`\n${parts.join(', ')}.`);
+  }
+
+  // Show stack tree
+  if (roots.length) {
+    console.log('\n\x1b[1mStack:\x1b[0m');
+    for (const root of roots) {
+      printTree(root);
+    }
+  }
+}

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -60,6 +60,11 @@ export function mergeBase(a, b) {
   return run('git', ['merge-base', a, b], { silent: true });
 }
 
+export function commitDistance(from, to) {
+  const out = run('git', ['rev-list', '--count', `${from}..${to}`], { silent: true });
+  return out ? Number(out) : Infinity;
+}
+
 export function rebaseOnto(onto, skip, branch) {
   try {
     execFileSync('git', ['rebase', '--onto', onto, skip, branch], {

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -1,0 +1,132 @@
+// Git and gh CLI helpers — no external dependencies.
+
+import { execSync } from 'node:child_process';
+
+// ── Shell execution ──
+
+export function exec(cmd, { silent = false } = {}) {
+  try {
+    return execSync(cmd, {
+      encoding: 'utf-8',
+      stdio: silent ? 'pipe' : ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch (e) {
+    if (silent) return null;
+    throw new Error(`Command failed: ${cmd}\n${e.stderr || e.message}`);
+  }
+}
+
+// ── Git helpers ──
+
+export function currentBranch() {
+  return exec('git symbolic-ref --short HEAD', { silent: true });
+}
+
+export function defaultBranch() {
+  const ref = exec('git symbolic-ref refs/remotes/origin/HEAD', { silent: true });
+  if (ref) return ref.replace('refs/remotes/origin/', '');
+  // fallback: try main, then master
+  const branches = exec('git branch -r', { silent: true }) || '';
+  if (branches.includes('origin/main')) return 'main';
+  if (branches.includes('origin/master')) return 'master';
+  return 'main';
+}
+
+export function isClean() {
+  try {
+    execSync('git diff --quiet && git diff --cached --quiet', {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      shell: true,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function fetch() {
+  exec('git fetch --prune origin');
+}
+
+export function localBranches() {
+  const out = exec('git branch --format="%(refname:short)"', { silent: true });
+  return out ? out.split('\n').filter(Boolean) : [];
+}
+
+export function remoteSha(branch) {
+  return exec(`git rev-parse origin/${branch}`, { silent: true });
+}
+
+export function localSha(branch) {
+  return exec(`git rev-parse ${branch}`, { silent: true });
+}
+
+export function mergeBase(a, b) {
+  return exec(`git merge-base ${a} ${b}`, { silent: true });
+}
+
+export function rebaseOnto(onto, skip, branch) {
+  try {
+    execSync(`git rebase --onto ${onto} ${skip} ${branch}`, {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    return { ok: true };
+  } catch (e) {
+    try { execSync('git rebase --abort', { stdio: 'pipe' }); } catch {}
+    return { ok: false, error: e.stderr || e.message };
+  }
+}
+
+export function pushForce(branch) {
+  exec(`git push --force-with-lease origin ${branch}`);
+}
+
+export function branchForceUpdate(branch, ref) {
+  exec(`git branch -f ${branch} ${ref}`);
+}
+
+export function resetHard(ref) {
+  exec(`git reset --hard ${ref}`);
+}
+
+export function checkout(branch) {
+  exec(`git checkout ${branch}`);
+}
+
+// ── gh CLI helpers ──
+
+export function ghPrList() {
+  const out = exec(
+    'gh pr list --author @me --state open --json number,headRefName,baseRefName,title,url',
+    { silent: true },
+  );
+  if (!out) return [];
+  return JSON.parse(out);
+}
+
+export function ghPrView(number) {
+  const out = exec(
+    `gh pr view ${number} --json number,headRefName,baseRefName,title,body,url`,
+    { silent: true },
+  );
+  if (!out) return null;
+  return JSON.parse(out);
+}
+
+export function ghPrCreate(head, base, title) {
+  const out = exec(
+    `gh pr create --base ${base} --head ${head} --title ${JSON.stringify(title)} --fill`,
+    { silent: true },
+  );
+  return out; // URL of created PR
+}
+
+export function ghPrEditBase(number, base) {
+  exec(`gh pr edit ${number} --base ${base}`, { silent: true });
+}
+
+export function ghPrComment(number, body) {
+  exec(`gh pr comment ${number} --body ${JSON.stringify(body)}`, { silent: true });
+}

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -1,105 +1,112 @@
 // Git and gh CLI helpers — no external dependencies.
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 // ── Shell execution ──
 
-export function exec(cmd, { silent = false } = {}) {
+function run(cmd, args, { silent = false } = {}) {
   try {
-    return execSync(cmd, {
+    return execFileSync(cmd, args, {
       encoding: 'utf-8',
       stdio: silent ? 'pipe' : ['pipe', 'pipe', 'pipe'],
     }).trim();
   } catch (e) {
     if (silent) return null;
-    throw new Error(`Command failed: ${cmd}\n${e.stderr || e.message}`);
+    throw new Error(`Command failed: ${cmd} ${args.join(' ')}\n${e.stderr || e.message}`);
   }
 }
 
 // ── Git helpers ──
 
 export function currentBranch() {
-  return exec('git symbolic-ref --short HEAD', { silent: true });
+  return run('git', ['symbolic-ref', '--short', 'HEAD'], { silent: true });
 }
 
 export function defaultBranch() {
-  const ref = exec('git symbolic-ref refs/remotes/origin/HEAD', { silent: true });
+  const ref = run('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], { silent: true });
   if (ref) return ref.replace('refs/remotes/origin/', '');
   // fallback: try main, then master
-  const branches = exec('git branch -r', { silent: true }) || '';
+  const branches = run('git', ['branch', '-r'], { silent: true }) || '';
   if (branches.includes('origin/main')) return 'main';
   if (branches.includes('origin/master')) return 'master';
   return 'main';
 }
 
 export function isClean() {
-  try {
-    execSync('git diff --quiet && git diff --cached --quiet', {
-      encoding: 'utf-8',
-      stdio: 'pipe',
-      shell: true,
-    });
-    return true;
-  } catch {
-    return false;
-  }
+  const diff = run('git', ['diff', '--quiet'], { silent: true });
+  if (diff === null) return false;
+  const cached = run('git', ['diff', '--cached', '--quiet'], { silent: true });
+  return cached !== null;
 }
 
 export function fetch() {
-  exec('git fetch --prune origin');
+  run('git', ['fetch', '--prune', 'origin']);
 }
 
 export function localBranches() {
-  const out = exec('git branch --format="%(refname:short)"', { silent: true });
+  const out = run('git', ['branch', '--format=%(refname:short)'], { silent: true });
   return out ? out.split('\n').filter(Boolean) : [];
 }
 
 export function remoteSha(branch) {
-  return exec(`git rev-parse origin/${branch}`, { silent: true });
+  return run('git', ['rev-parse', `origin/${branch}`], { silent: true });
 }
 
 export function localSha(branch) {
-  return exec(`git rev-parse ${branch}`, { silent: true });
+  return run('git', ['rev-parse', branch], { silent: true });
 }
 
 export function mergeBase(a, b) {
-  return exec(`git merge-base ${a} ${b}`, { silent: true });
+  return run('git', ['merge-base', a, b], { silent: true });
 }
 
 export function rebaseOnto(onto, skip, branch) {
   try {
-    execSync(`git rebase --onto ${onto} ${skip} ${branch}`, {
+    execFileSync('git', ['rebase', '--onto', onto, skip, branch], {
       encoding: 'utf-8',
       stdio: 'pipe',
     });
     return { ok: true };
   } catch (e) {
-    try { execSync('git rebase --abort', { stdio: 'pipe' }); } catch {}
+    try { execFileSync('git', ['rebase', '--abort'], { stdio: 'pipe' }); } catch {}
     return { ok: false, error: e.stderr || e.message };
   }
 }
 
+export function pushUpstream(branch) {
+  run('git', ['push', '-u', 'origin', branch]);
+}
+
 export function pushForce(branch) {
-  exec(`git push --force-with-lease origin ${branch}`);
+  run('git', ['push', '--force-with-lease', 'origin', branch]);
 }
 
 export function branchForceUpdate(branch, ref) {
-  exec(`git branch -f ${branch} ${ref}`);
+  run('git', ['branch', '-f', branch, ref]);
 }
 
 export function resetHard(ref) {
-  exec(`git reset --hard ${ref}`);
+  run('git', ['reset', '--hard', ref]);
 }
 
 export function checkout(branch) {
-  exec(`git checkout ${branch}`);
+  run('git', ['checkout', branch]);
+}
+
+export function ensureLocalBranch(branch) {
+  run('git', ['branch', branch, `origin/${branch}`], { silent: true });
+}
+
+export function deleteBranch(branch) {
+  run('git', ['branch', '-D', branch], { silent: true });
 }
 
 // ── gh CLI helpers ──
 
 export function ghPrList() {
-  const out = exec(
-    'gh pr list --author @me --state open --json number,headRefName,baseRefName,title,url',
+  const out = run(
+    'gh', ['pr', 'list', '--author', '@me', '--state', 'open',
+           '--json', 'number,headRefName,baseRefName,title,url'],
     { silent: true },
   );
   if (!out) return [];
@@ -107,8 +114,9 @@ export function ghPrList() {
 }
 
 export function ghPrView(number) {
-  const out = exec(
-    `gh pr view ${number} --json number,headRefName,baseRefName,title,body,url`,
+  const out = run(
+    'gh', ['pr', 'view', String(number),
+           '--json', 'number,headRefName,baseRefName,title,body,url'],
     { silent: true },
   );
   if (!out) return null;
@@ -116,17 +124,17 @@ export function ghPrView(number) {
 }
 
 export function ghPrCreate(head, base, title) {
-  const out = exec(
-    `gh pr create --base ${base} --head ${head} --title ${JSON.stringify(title)} --fill`,
+  const out = run(
+    'gh', ['pr', 'create', '--base', base, '--head', head, '--title', title, '--fill'],
     { silent: true },
   );
   return out; // URL of created PR
 }
 
 export function ghPrEditBase(number, base) {
-  exec(`gh pr edit ${number} --base ${base}`, { silent: true });
+  run('gh', ['pr', 'edit', String(number), '--base', base], { silent: true });
 }
 
 export function ghPrComment(number, body) {
-  exec(`gh pr comment ${number} --body ${JSON.stringify(body)}`, { silent: true });
+  run('gh', ['pr', 'comment', String(number), '--body', body], { silent: true });
 }

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -1,0 +1,53 @@
+import { sync } from './commands/sync.mjs';
+import { restack } from './commands/restack.mjs';
+import { submit } from './commands/submit.mjs';
+import { move } from './commands/move.mjs';
+
+const COMMANDS = { sync, restack, submit, move };
+
+const HELP = `\x1b[1mstaqd\x1b[0m — Stacked PR CLI
+
+\x1b[1mUSAGE\x1b[0m
+  st <command> [options]
+
+\x1b[1mCOMMANDS\x1b[0m
+  sync       Sync local branches with remote (after Actions restack)
+  restack    Locally rebase stack branches onto their parents
+  submit     Push branches and create/update PRs
+  move       Move current branch to a new parent
+
+\x1b[1mOPTIONS\x1b[0m
+  --help     Show help
+  --dry-run  Show what would be done without making changes`;
+
+export async function run(args) {
+  const command = args[0];
+
+  if (!command || command === '--help' || command === 'help') {
+    console.log(HELP);
+    return;
+  }
+
+  const handler = COMMANDS[command];
+  if (!handler) {
+    console.error(`Unknown command: ${command}\n`);
+    console.log(HELP);
+    process.exit(1);
+  }
+
+  const flags = parseFlags(args.slice(1));
+  await handler(flags);
+}
+
+function parseFlags(args) {
+  const flags = { _: [] };
+  for (const arg of args) {
+    if (arg.startsWith('--')) {
+      const [key, val] = arg.slice(2).split('=');
+      flags[key] = val ?? true;
+    } else {
+      flags._.push(arg);
+    }
+  }
+  return flags;
+}

--- a/cli/stack.mjs
+++ b/cli/stack.mjs
@@ -1,0 +1,86 @@
+// Stack tree discovery and utilities.
+
+import * as git from './git.mjs';
+
+/**
+ * Build a stack tree from open PRs.
+ * Returns { nodes: Map<branch, node>, roots: node[] }
+ * where node = { branch, pr, base, title, url, children: node[] }
+ */
+export function buildStackTree(prs) {
+  const defBranch = git.defaultBranch();
+  const byHead = new Map();
+
+  for (const pr of prs) {
+    byHead.set(pr.headRefName, {
+      branch: pr.headRefName,
+      pr: pr.number,
+      base: pr.baseRefName,
+      title: pr.title,
+      url: pr.url,
+      children: [],
+    });
+  }
+
+  const roots = [];
+  for (const node of byHead.values()) {
+    const parent = byHead.get(node.base);
+    if (parent) {
+      parent.children.push(node);
+    } else {
+      // base is default branch or non-PR branch → root
+      roots.push(node);
+    }
+  }
+
+  return { nodes: byHead, roots };
+}
+
+/**
+ * Find the stack subtree that contains the given branch.
+ * Returns the root node of that stack, or null.
+ */
+export function findStackFor(branch, roots, nodes) {
+  // If branch is a root
+  for (const root of roots) {
+    if (containsBranch(root, branch)) return root;
+  }
+  return null;
+}
+
+function containsBranch(node, branch) {
+  if (node.branch === branch) return true;
+  return node.children.some(c => containsBranch(c, branch));
+}
+
+/**
+ * Walk tree in DFS order (parent before children).
+ * Calls fn(node, parent) for each node.
+ */
+export function walkDFS(node, fn, parent = null) {
+  fn(node, parent);
+  for (const child of node.children) {
+    walkDFS(child, fn, node);
+  }
+}
+
+/**
+ * Collect all nodes in DFS order.
+ */
+export function collectDFS(node) {
+  const result = [];
+  walkDFS(node, (n) => result.push(n));
+  return result;
+}
+
+/**
+ * Print stack tree.
+ */
+export function printTree(node, indent = 0) {
+  const prefix = '  '.repeat(indent);
+  const current = node.branch === git.currentBranch() ? ' \x1b[36m◀\x1b[0m' : '';
+  console.log(`${prefix}${indent > 0 ? '└─ ' : ''}#${node.pr} \x1b[1m${node.branch}\x1b[0m${current}`);
+  for (const child of node.children) {
+    printTree(child, indent + 1);
+  }
+}

--- a/cli/stack.mjs
+++ b/cli/stack.mjs
@@ -8,7 +8,6 @@ import * as git from './git.mjs';
  * where node = { branch, pr, base, title, url, children: node[] }
  */
 export function buildStackTree(prs) {
-  const defBranch = git.defaultBranch();
   const byHead = new Map();
 
   for (const pr of prs) {
@@ -41,16 +40,13 @@ export function buildStackTree(prs) {
  * Returns the root node of that stack, or null.
  */
 export function findStackFor(branch, roots, nodes) {
-  // If branch is a root
-  for (const root of roots) {
-    if (containsBranch(root, branch)) return root;
+  let node = nodes.get(branch);
+  if (!node) return null;
+  // Walk up via base to find the stack root
+  while (nodes.has(node.base)) {
+    node = nodes.get(node.base);
   }
-  return null;
-}
-
-function containsBranch(node, branch) {
-  if (node.branch === branch) return true;
-  return node.children.some(c => containsBranch(c, branch));
+  return node;
 }
 
 /**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,16 @@
+import security from "eslint-plugin-security";
+
+export default [
+  {
+    ignores: ["node_modules/"],
+  },
+  {
+    files: ["src/**/*.js", "cli/**/*.mjs", "bin/**/*.mjs"],
+    plugins: { security },
+    rules: {
+      ...security.configs.recommended.rules,
+      "no-eval": "error",
+      "no-implied-eval": "error",
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "staqd",
+  "version": "1.1.0",
+  "description": "Stacked PR merge queue powered by GitHub Actions and PR comments.",
+  "license": "MIT",
+  "author": "siner308",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/siner308/staqd.git"
+  },
+  "bin": {
+    "st": "./bin/st.mjs"
+  },
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "bin/",
+    "cli/",
+    "src/",
+    "action.yml"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -20,5 +20,12 @@
     "cli/",
     "src/",
     "action.yml"
-  ]
+  ],
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "eslint": "^9",
+    "eslint-plugin-security": "^3"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,695 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      eslint:
+        specifier: ^9
+        version: 9.39.4
+      eslint-plugin-security:
+        specifier: ^3
+        version: 3.0.1
+
+packages:
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-security@3.0.1:
+    resolution: {integrity: sha512-XjVGBhtDZJfyuhIxnQ/WMm385RbX3DBu7H1J7HNNhmB2tnGxMeqVSnYv79oAj992ayvIBZghsymwkYFS6cGH4Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  safe-regex@2.1.1:
+    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.14.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-security@3.0.1:
+    dependencies:
+      safe-regex: 2.1.1
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.39.4:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.1
+      keyv: 4.5.4
+
+  flatted@3.4.1: {}
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  regexp-tree@0.1.27: {}
+
+  resolve-from@4.0.0: {}
+
+  safe-regex@2.1.1:
+    dependencies:
+      regexp-tree: 0.1.27
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yocto-queue@0.1.0: {}


### PR DESCRIPTION

  ## Summary                                                                      
                                                                                  
  • Add Node.js CLI (st) distributed via npm for local stack operations          
  • st sync — sync local branches with remote after Actions restack (solves the 
  "delete and re-checkout" pain point vs Graphite)                                
  • st restack — locally rebase stack branches onto parents (no Actions roundtrip)
  • st submit — push branches and create/update PRs with correct base branches  
  • st move <parent> — move current branch to a new parent                      
  • All commands support --dry-run                                               
  • No external npm dependencies — uses only git and gh CLI                     
  • Adds CLAUDE.md and dev custom commands for future development                
                                                                                  
  ## Test plan                                                                    
                                                                                  
  [ ] node bin/st.mjs --help shows command list                                   
  [ ] st sync --dry-run in a repo with open PRs                                   
  [ ] st restack --dry-run on a stacked branch                                    
  [ ] st submit on a new branch creates PR with correct base                      
  [ ] st move <parent> --dry-run shows rebase plan                                
  [ ] npm link && st sync works as installed CLI                                  
  [ ] Error cases: dirty worktree, detached HEAD, missing gh CLI                  
                                                                                  
  🤖 Generated with Claude Code https://claude.com/claude-code                    