### PR TITLE
feat: add st track, create, log, up, down and stack-wide submit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Staqd (`/stakt/`) is a stacked PR tool with two components:
 1. **GitHub Action** — Composite action for managing stacked PRs via PR comment commands (`st merge`, `st restack`, `st discover`, `st merge-all`, `st help`)
-2. **CLI** (`st`) — Local CLI for syncing, restacking, submitting, and moving branches (`st sync`, `st restack`, `st submit`, `st move`)
+2. **CLI** (`st`) — Local CLI for managing stacked branches (`st track`, `st create`, `st submit`, `st log`, `st up`, `st down`, `st sync`, `st restack`, `st move`)
 
 Written in plain JavaScript (ESM), no external npm dependencies. Distributed via `npx staqd` or `npm i -g staqd`.
 
@@ -55,7 +55,7 @@ Supports both `GITHUB_TOKEN` and GitHub App tokens (via `app-id` + `app-private-
 - **`cli/index.mjs`** — Command dispatcher and flag parser
 - **`cli/git.mjs`** — Git and `gh` CLI wrappers (no Octokit, uses `child_process.execSync`)
 - **`cli/stack.mjs`** — Stack tree discovery from PR list (`gh pr list` → build tree from base/head relationships)
-- **`cli/commands/`** — One file per command: `sync.mjs`, `restack.mjs`, `submit.mjs`, `move.mjs`
+- **`cli/commands/`** — One file per command: `sync.mjs`, `restack.mjs`, `submit.mjs`, `move.mjs`, `track.mjs`, `create.mjs`, `log.mjs`, `navigate.mjs`
 
 ## Code Conventions
 

--- a/cli/commands/create.mjs
+++ b/cli/commands/create.mjs
@@ -1,6 +1,5 @@
 // st create — Create a new branch and auto-track it.
 
-import { execFileSync } from 'node:child_process';
 import * as git from '../git.mjs';
 
 export function create(flags) {
@@ -20,7 +19,7 @@ export function create(flags) {
   }
 
   // Create and checkout new branch
-  execFileSync('git', ['checkout', '-b', name], { encoding: 'utf-8', stdio: 'pipe' });
+  git.checkoutNew(name);
 
   // Auto-track with current branch as parent
   git.setTrackedParent(name, current);

--- a/cli/commands/create.mjs
+++ b/cli/commands/create.mjs
@@ -1,0 +1,28 @@
+// st create — Create a new branch and auto-track it.
+
+import { execFileSync } from 'node:child_process';
+import * as git from '../git.mjs';
+
+export function create(flags) {
+  const name = flags._[0];
+  if (!name) throw new Error('Usage: st create <branch-name>');
+
+  const current = git.currentBranch();
+  if (!current) throw new Error('Not on a branch (detached HEAD).');
+
+  const defBranch = git.defaultBranch();
+
+  // Current branch must be default branch or tracked
+  if (current !== defBranch && !git.getTrackedParent(current)) {
+    throw new Error(
+      `Current branch "${current}" is not tracked. Track it first with: st track`
+    );
+  }
+
+  // Create and checkout new branch
+  execFileSync('git', ['checkout', '-b', name], { encoding: 'utf-8', stdio: 'pipe' });
+
+  // Auto-track with current branch as parent
+  git.setTrackedParent(name, current);
+  console.log(`\x1b[32m✓\x1b[0m Created and tracking \x1b[1m${name}\x1b[0m → \x1b[1m${current}\x1b[0m`);
+}

--- a/cli/commands/log.mjs
+++ b/cli/commands/log.mjs
@@ -1,0 +1,42 @@
+// st log — Visualize the tracked stack tree.
+
+import * as git from '../git.mjs';
+
+export function log() {
+  const tracked = git.listTrackedBranches();
+  const current = git.currentBranch();
+  const defBranch = git.defaultBranch();
+
+  if (tracked.length === 0) {
+    console.log('No tracked branches. Use \x1b[1mst track\x1b[0m to start.');
+    return;
+  }
+
+  // Build parent → children map
+  const childrenOf = new Map();
+  for (const { branch, parent } of tracked) {
+    if (!childrenOf.has(parent)) childrenOf.set(parent, []);
+    childrenOf.get(parent).push(branch);
+  }
+
+  // Print tree starting from default branch roots
+  console.log(`\x1b[1m${defBranch}\x1b[0m`);
+  const roots = childrenOf.get(defBranch) || [];
+  for (let i = 0; i < roots.length; i++) {
+    const isLast = i === roots.length - 1;
+    printBranch(roots[i], '', isLast, childrenOf, current);
+  }
+}
+
+function printBranch(branch, prefix, isLast, childrenOf, current) {
+  const connector = isLast ? '└─ ' : '├─ ';
+  const marker = branch === current ? ' \x1b[36m◀\x1b[0m' : '';
+  console.log(`${prefix}${connector}\x1b[1m${branch}\x1b[0m${marker}`);
+
+  const children = childrenOf.get(branch) || [];
+  const childPrefix = prefix + (isLast ? '   ' : '│  ');
+  for (let i = 0; i < children.length; i++) {
+    const childIsLast = i === children.length - 1;
+    printBranch(children[i], childPrefix, childIsLast, childrenOf, current);
+  }
+}

--- a/cli/commands/navigate.mjs
+++ b/cli/commands/navigate.mjs
@@ -1,0 +1,38 @@
+// st up / st down — Navigate within the tracked stack.
+
+import * as git from '../git.mjs';
+
+export function up() {
+  const current = git.currentBranch();
+  if (!current) throw new Error('Not on a branch (detached HEAD).');
+
+  const tracked = git.listTrackedBranches();
+  const children = tracked.filter(t => t.parent === current);
+
+  if (children.length === 0) {
+    throw new Error('Already at top of stack (no children).');
+  }
+
+  // If multiple children, pick the first one
+  const target = children[0].branch;
+  if (children.length > 1) {
+    console.log(`\x1b[33m!\x1b[0m Multiple children: ${children.map(c => c.branch).join(', ')}`);
+    console.log(`  Checking out first: ${target}`);
+  }
+
+  git.checkout(target);
+  console.log(`\x1b[32m✓\x1b[0m \x1b[1m${target}\x1b[0m`);
+}
+
+export function down() {
+  const current = git.currentBranch();
+  if (!current) throw new Error('Not on a branch (detached HEAD).');
+
+  const parent = git.getTrackedParent(current);
+  if (!parent) {
+    throw new Error('Already at bottom of stack (not tracked or no parent).');
+  }
+
+  git.checkout(parent);
+  console.log(`\x1b[32m✓\x1b[0m \x1b[1m${parent}\x1b[0m`);
+}

--- a/cli/commands/submit.mjs
+++ b/cli/commands/submit.mjs
@@ -11,34 +11,55 @@ export async function submit(flags) {
     throw new Error('Not on a branch (detached HEAD).');
   }
 
+  // Collect tracked chain: walk from current up to root
+  const chain = [];
+  let b = current;
+  while (b) {
+    const parent = git.getTrackedParent(b);
+    if (parent) {
+      chain.push(b);
+      b = parent;
+    } else {
+      // b is either default branch (stop) or untracked (include current only)
+      if (b !== git.defaultBranch()) chain.push(b);
+      break;
+    }
+  }
+  chain.reverse(); // root-first order
+
+  // If no tracked chain, fall back to just the current branch
+  if (chain.length === 0) chain.push(current);
+
   // Push current branch first
   console.log(`Pushing ${current}...`);
   if (!dryRun) {
     git.pushUpstream(current);
   }
 
-  // Discover stack from PRs
-  const prs = git.ghPrList();
-  const { roots, nodes } = buildStackTree(prs);
+  // Discover existing PRs
+  let prs = git.ghPrList();
 
-  // Check if current branch already has a PR
-  const existingPr = prs.find(p => p.headRefName === current);
-
-  if (!existingPr) {
-    // Need to create a PR — figure out the base branch
-    const base = detectBase(current, prs);
-
-    console.log(`Creating PR: ${current} → ${base}`);
-    if (!dryRun) {
-      // Generate title from branch name
-      const title = branchToTitle(current);
-      const url = git.ghPrCreate(current, base, title);
-      console.log(`  \x1b[32m✓\x1b[0m Created: ${url}`);
-    } else {
-      console.log(`  \x1b[33m~\x1b[0m Would create PR: ${current} → ${base}`);
+  // Create PRs for each tracked branch in the chain (root → leaf)
+  const defBranch = git.defaultBranch();
+  for (const branch of chain) {
+    const existingPr = prs.find(p => p.headRefName === branch);
+    if (existingPr) {
+      console.log(`  \x1b[90m·\x1b[0m PR #${existingPr.number} already exists for ${branch}`);
+      continue;
     }
-  } else {
-    console.log(`  \x1b[90m·\x1b[0m PR #${existingPr.number} already exists`);
+
+    const base = git.getTrackedParent(branch) || detectBase(branch, prs);
+    console.log(`Creating PR: ${branch} → ${base}`);
+    if (!dryRun) {
+      git.pushUpstream(branch);
+      const title = branchToTitle(branch);
+      const url = git.ghPrCreate(branch, base, title);
+      console.log(`  \x1b[32m✓\x1b[0m Created: ${url}`);
+      // Re-fetch so subsequent iterations see the new PR
+      prs = git.ghPrList();
+    } else {
+      console.log(`  \x1b[33m~\x1b[0m Would create PR: ${branch} → ${base}`);
+    }
   }
 
   // Re-fetch PR list after potential creation

--- a/cli/commands/track.mjs
+++ b/cli/commands/track.mjs
@@ -1,0 +1,110 @@
+// st track — Register branches in the stack.
+
+import * as git from '../git.mjs';
+
+export function track(flags) {
+  if (flags.list) {
+    listTracked();
+    return;
+  }
+
+  const current = git.currentBranch();
+  if (!current) throw new Error('Not on a branch (detached HEAD).');
+
+  const defBranch = git.defaultBranch();
+  if (current === defBranch) {
+    throw new Error(`Cannot track the default branch (${defBranch}).`);
+  }
+
+  const parent = flags.parent || detectParent(current);
+
+  // Validate parent chain reaches default branch
+  if (!validateParent(parent)) {
+    throw new Error(
+      `Cannot track: parent "${parent}" is not tracked and does not reach ${defBranch}.\n` +
+      `Either track "${parent}" first, or use --parent to specify a valid parent.`
+    );
+  }
+
+  git.setTrackedParent(current, parent);
+  console.log(`\x1b[32m✓\x1b[0m Tracking \x1b[1m${current}\x1b[0m → \x1b[1m${parent}\x1b[0m`);
+}
+
+export function untrack() {
+  const current = git.currentBranch();
+  if (!current) throw new Error('Not on a branch (detached HEAD).');
+
+  const parent = git.getTrackedParent(current);
+  if (!parent) {
+    console.log(`\x1b[90m·\x1b[0m ${current} is not tracked`);
+    return;
+  }
+
+  git.unsetTrackedParent(current);
+  console.log(`\x1b[32m✓\x1b[0m Untracked \x1b[1m${current}\x1b[0m`);
+}
+
+function listTracked() {
+  const tracked = git.listTrackedBranches();
+  const defBranch = git.defaultBranch();
+  const current = git.currentBranch();
+
+  if (tracked.length === 0) {
+    console.log('No tracked branches.');
+    return;
+  }
+
+  console.log('\x1b[1mTracked branches:\x1b[0m\n');
+  for (const { branch, parent } of tracked) {
+    const marker = branch === current ? ' \x1b[36m◀\x1b[0m' : '';
+    console.log(`  \x1b[1m${branch}\x1b[0m → ${parent}${marker}`);
+  }
+}
+
+/**
+ * Detect the parent for the current branch.
+ * Finds the closest tracked ancestor or the default branch.
+ */
+function detectParent(branch) {
+  const defBranch = git.defaultBranch();
+  const tracked = git.listTrackedBranches();
+
+  // Check tracked branches that are ancestors of the current branch
+  let best = null;
+  let bestDistance = Infinity;
+
+  for (const { branch: trackedBranch } of tracked) {
+    const mb = git.mergeBase(trackedBranch, branch);
+    const sha = git.localSha(trackedBranch);
+    if (mb && sha && mb === sha) {
+      const distance = git.commitDistance(sha, branch);
+      if (distance < bestDistance) {
+        best = trackedBranch;
+        bestDistance = distance;
+      }
+    }
+  }
+
+  return best || defBranch;
+}
+
+/**
+ * Validate that a parent is either the default branch or a tracked branch
+ * whose chain reaches the default branch.
+ */
+function validateParent(parent) {
+  const defBranch = git.defaultBranch();
+  if (parent === defBranch) return true;
+
+  let b = parent;
+  const visited = new Set();
+  while (b) {
+    if (visited.has(b)) return false; // cycle protection
+    visited.add(b);
+    const p = git.getTrackedParent(b);
+    if (!p) return false;  // chain broken
+    if (p === defBranch) return true;
+    b = p;
+  }
+  return false;
+}

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -98,6 +98,10 @@ export function checkout(branch) {
   run('git', ['checkout', branch]);
 }
 
+export function checkoutNew(branch) {
+  run('git', ['checkout', '-b', branch]);
+}
+
 export function ensureLocalBranch(branch) {
   run('git', ['branch', branch, `origin/${branch}`], { silent: true });
 }
@@ -127,7 +131,8 @@ export function listTrackedBranches() {
     const spaceIdx = line.indexOf(' ');
     const key = line.slice(0, spaceIdx);
     const parent = line.slice(spaceIdx + 1);
-    const branch = key.replace(/^branch\./, '').replace(/\.staqd-parent$/, '');
+    const match = key.match(/^branch\.(.+)\.staqd-parent$/);
+    const branch = match ? match[1] : key;
     return { branch, parent };
   });
 }

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -106,6 +106,32 @@ export function deleteBranch(branch) {
   run('git', ['branch', '-D', branch], { silent: true });
 }
 
+// ── Track helpers (git config local) ──
+
+export function getTrackedParent(branch) {
+  return run('git', ['config', '--local', `branch.${branch}.staqd-parent`], { silent: true });
+}
+
+export function setTrackedParent(branch, parent) {
+  run('git', ['config', '--local', `branch.${branch}.staqd-parent`, parent]);
+}
+
+export function unsetTrackedParent(branch) {
+  run('git', ['config', '--local', '--unset', `branch.${branch}.staqd-parent`], { silent: true });
+}
+
+export function listTrackedBranches() {
+  const out = run('git', ['config', '--local', '--get-regexp', 'branch\\..*\\.staqd-parent'], { silent: true });
+  if (!out) return [];
+  return out.split('\n').filter(Boolean).map(line => {
+    const spaceIdx = line.indexOf(' ');
+    const key = line.slice(0, spaceIdx);
+    const parent = line.slice(spaceIdx + 1);
+    const branch = key.replace(/^branch\./, '').replace(/\.staqd-parent$/, '');
+    return { branch, parent };
+  });
+}
+
 // ── gh CLI helpers ──
 
 export function ghPrList() {

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -143,3 +143,4 @@ export function ghPrEditBase(number, base) {
 export function ghPrComment(number, body) {
   run('gh', ['pr', 'comment', String(number), '--body', body], { silent: true });
 }
+// feature A

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -144,3 +144,4 @@ export function ghPrComment(number, body) {
   run('gh', ['pr', 'comment', String(number), '--body', body], { silent: true });
 }
 // feature A
+// extra change in A

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -51,3 +51,4 @@ function parseFlags(args) {
   }
   return flags;
 }
+// feature C

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -2,8 +2,12 @@ import { sync } from './commands/sync.mjs';
 import { restack } from './commands/restack.mjs';
 import { submit } from './commands/submit.mjs';
 import { move } from './commands/move.mjs';
+import { track, untrack } from './commands/track.mjs';
+import { create } from './commands/create.mjs';
+import { log } from './commands/log.mjs';
+import { up, down } from './commands/navigate.mjs';
 
-const COMMANDS = { sync, restack, submit, move };
+const COMMANDS = { sync, restack, submit, move, track, untrack, create, log, up, down };
 
 const HELP = `\x1b[1mstaqd\x1b[0m — Stacked PR CLI
 
@@ -15,6 +19,12 @@ const HELP = `\x1b[1mstaqd\x1b[0m — Stacked PR CLI
   restack    Locally rebase stack branches onto their parents
   submit     Push branches and create/update PRs
   move       Move current branch to a new parent
+  track      Register current branch in the stack (--parent, --list)
+  untrack    Remove current branch from the stack
+  create     Create a new branch and auto-track it
+  log        Visualize the tracked stack tree
+  up         Move to child branch in the stack
+  down       Move to parent branch in the stack
 
 \x1b[1mOPTIONS\x1b[0m
   --help     Show help


### PR DESCRIPTION
## Summary

- Add `st track` / `st untrack` for explicit branch tracking via git config (`branch.<name>.staqd-parent`)
- Add `st create` for branch creation with auto-tracking
- Add `st log` for tracked stack tree visualization
- Add `st up` / `st down` for stack navigation
- Update `st submit` to create PRs for the entire tracked chain (root → leaf), not just the current branch
- Add track helpers to `cli/git.mjs` (`getTrackedParent`, `setTrackedParent`, `unsetTrackedParent`, `listTrackedBranches`)

## Motivation

Previously `st submit` only created a PR for the current branch. With stacked workflows (`main → a → b → c`), users had to run `st submit` on each branch individually. Now, `st track` registers the parent relationship in git config, and `st submit` walks the chain to create all missing PRs at once — similar to Graphite's `gt track` + `gt submit`.

## New Commands

| Command | Description |
|---|---|
| `st track` | Register current branch (auto-detect or `--parent`) |
| `st track --list` | Show all tracked branches |
| `st untrack` | Remove current branch from tracking |
| `st create <name>` | Create branch + auto-track |
| `st log` | Tree visualization of tracked stack |
| `st up` | Checkout child branch |
| `st down` | Checkout parent branch |

## Design Decisions

- **Git config storage** (`branch.<name>.staqd-parent`): Same approach as Graphite. No external DB, survives branch operations, portable.
- **Parent validation**: Parent must be default branch or a tracked branch whose chain reaches default branch. Prevents orphan PRs.
- **Backward compatible**: `st submit` without any tracked branches falls back to the existing `detectBase` behavior.

## Test plan

- [ ] `st track --parent=main` on a branch → verify git config set
- [ ] `st track --list` shows tracked branches
- [ ] `st untrack` removes tracking
- [ ] `st log` shows tree with current branch highlighted
- [ ] `st create <name>` creates branch and auto-tracks
- [ ] `st up` / `st down` navigate the stack
- [ ] `st submit --dry-run` on a tracked stack shows PRs to create for entire chain
- [ ] `st submit` creates PRs for all unsubmitted branches in chain
- [ ] Untracked branch + `st submit` falls back to existing behavior

---
*Generated with [Claude Code](https://claude.com/claude-code)*
