### PR TITLE
fix: handle existing PRs in st submit gracefully

### DIFF
--- a/cli/commands/submit.mjs
+++ b/cli/commands/submit.mjs
@@ -53,8 +53,18 @@ export async function submit(flags) {
     if (!dryRun) {
       git.pushUpstream(branch);
       const title = branchToTitle(branch);
-      const url = git.ghPrCreate(branch, base, title);
-      console.log(`  \x1b[32m✓\x1b[0m Created: ${url}`);
+      try {
+        const url = git.ghPrCreate(branch, base, title);
+        console.log(`  \x1b[32m✓\x1b[0m Created: ${url}`);
+      } catch {
+        // PR creation failed — check if one already exists (possibly by another author)
+        const existing = git.ghPrListForBranch(branch);
+        if (existing.length > 0) {
+          console.log(`  \x1b[90m·\x1b[0m PR #${existing[0].number} already exists for ${branch}`);
+        } else {
+          console.log(`  \x1b[31m✗\x1b[0m Failed to create PR for ${branch}`);
+        }
+      }
       // Re-fetch so subsequent iterations see the new PR
       prs = git.ghPrList();
     } else {
@@ -62,8 +72,14 @@ export async function submit(flags) {
     }
   }
 
-  // Re-fetch PR list after potential creation
-  const freshPrs = dryRun ? prs : git.ghPrList();
+  // Re-fetch PR list after potential creation, including PRs by other authors for tracked branches
+  let freshPrs = dryRun ? prs : git.ghPrList();
+  for (const branch of chain) {
+    if (!freshPrs.find(p => p.headRefName === branch)) {
+      const others = git.ghPrListForBranch(branch);
+      if (others.length > 0) freshPrs.push(others[0]);
+    }
+  }
   const { roots: freshRoots, nodes: freshNodes } = buildStackTree(freshPrs);
 
   // Push all branches in the current stack

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -160,11 +160,19 @@ export function ghPrView(number) {
 }
 
 export function ghPrCreate(head, base, title) {
-  const out = run(
+  return run(
     'gh', ['pr', 'create', '--base', base, '--head', head, '--title', title, '--fill'],
+  );
+}
+
+export function ghPrListForBranch(branch) {
+  const out = run(
+    'gh', ['pr', 'list', '--head', branch, '--state', 'open',
+           '--json', 'number,headRefName,baseRefName,title,url'],
     { silent: true },
   );
-  return out; // URL of created PR
+  if (!out) return [];
+  return JSON.parse(out);
 }
 
 export function ghPrEditBase(number, base) {


### PR DESCRIPTION
## Summary
- `ghPrCreate`에서 `silent: true` 제거하여 PR 생성 실패 시 에러가 보이도록 수정
- PR 생성 실패 시 `ghPrListForBranch`로 기존 PR 존재 여부를 확인하는 fallback 추가
- `freshPrs` 빌드 시 `--author @me` 필터에 빠진 tracked 브랜치의 PR을 보충하여 스택 트리가 완전하게 구성되도록 수정 → force push 정상 동작

## Problem
`st submit`에서 이미 PR이 있는 브랜치에 대해:
1. `ghPrList`의 `--author @me` 필터로 인해 다른 방식으로 생성된 PR을 감지하지 못함
2. `ghPrCreate`가 `silent: true`로 실행되어 실패 시 `null` 반환 → `Created: null` 출력
3. 스택 트리에서 해당 브랜치가 누락되어 force push가 실행되지 않음

## Test plan
- [ ] tracked 브랜치에 이미 PR이 있는 상태에서 `st submit` 실행 → 정상 push 확인
- [ ] PR이 없는 브랜치에서 `st submit` 실행 → PR 생성 정상 동작 확인
- [ ] `--dry-run` 플래그 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
