### PR TITLE
fix: harden st submit safety gate and CLI UX

### DIFF
--- a/cli/commands/create.mjs
+++ b/cli/commands/create.mjs
@@ -2,7 +2,17 @@
 
 import * as git from '../git.mjs';
 
+export const spec = {
+  name: 'create',
+  summary: 'Create a new branch and auto-track it',
+  usage: 'st create <branch-name> [--dry-run]',
+  flags: {
+    'dry-run': { description: 'Show what would be created without modifying branches' },
+  },
+};
+
 export function create(flags) {
+  const dryRun = flags['dry-run'];
   const name = flags._[0];
   if (!name) throw new Error('Usage: st create <branch-name>');
 
@@ -11,17 +21,18 @@ export function create(flags) {
 
   const defBranch = git.defaultBranch();
 
-  // Current branch must be default branch or tracked
   if (current !== defBranch && !git.getTrackedParent(current)) {
     throw new Error(
       `Current branch "${current}" is not tracked. Track it first with: st track`
     );
   }
 
-  // Create and checkout new branch
-  git.checkoutNew(name);
+  if (dryRun) {
+    console.log(`\x1b[33m~\x1b[0m Would create branch \x1b[1m${name}\x1b[0m tracking \x1b[1m${current}\x1b[0m`);
+    return;
+  }
 
-  // Auto-track with current branch as parent
+  git.checkoutNew(name);
   git.setTrackedParent(name, current);
   console.log(`\x1b[32m✓\x1b[0m Created and tracking \x1b[1m${name}\x1b[0m → \x1b[1m${current}\x1b[0m`);
 }

--- a/cli/commands/log.mjs
+++ b/cli/commands/log.mjs
@@ -2,6 +2,13 @@
 
 import * as git from '../git.mjs';
 
+export const spec = {
+  name: 'log',
+  summary: 'Visualize the tracked stack tree',
+  usage: 'st log',
+  flags: {},
+};
+
 export function log() {
   const tracked = git.listTrackedBranches();
   const current = git.currentBranch();

--- a/cli/commands/move.mjs
+++ b/cli/commands/move.mjs
@@ -3,6 +3,15 @@
 import * as git from '../git.mjs';
 import { buildStackTree, printTree } from '../stack.mjs';
 
+export const spec = {
+  name: 'move',
+  summary: 'Move current branch to a new parent',
+  usage: 'st move <parent-branch> [--dry-run]',
+  flags: {
+    'dry-run': { description: 'Show what would be rebased without modifying branches' },
+  },
+};
+
 export async function move(flags) {
   const dryRun = flags['dry-run'];
   const newParent = flags._[0];

--- a/cli/commands/navigate.mjs
+++ b/cli/commands/navigate.mjs
@@ -2,7 +2,26 @@
 
 import * as git from '../git.mjs';
 
-export function up() {
+export const upSpec = {
+  name: 'up',
+  summary: 'Move to child branch in the stack',
+  usage: 'st up [--dry-run]',
+  flags: {
+    'dry-run': { description: 'Show which branch would be checked out' },
+  },
+};
+
+export const downSpec = {
+  name: 'down',
+  summary: 'Move to parent branch in the stack',
+  usage: 'st down [--dry-run]',
+  flags: {
+    'dry-run': { description: 'Show which branch would be checked out' },
+  },
+};
+
+export function up(flags = {}) {
+  const dryRun = flags['dry-run'];
   const current = git.currentBranch();
   if (!current) throw new Error('Not on a branch (detached HEAD).');
 
@@ -13,18 +32,22 @@ export function up() {
     throw new Error('Already at top of stack (no children).');
   }
 
-  // If multiple children, pick the first one
   const target = children[0].branch;
   if (children.length > 1) {
     console.log(`\x1b[33m!\x1b[0m Multiple children: ${children.map(c => c.branch).join(', ')}`);
     console.log(`  Checking out first: ${target}`);
   }
 
+  if (dryRun) {
+    console.log(`\x1b[33m~\x1b[0m Would checkout \x1b[1m${target}\x1b[0m`);
+    return;
+  }
   git.checkout(target);
   console.log(`\x1b[32m✓\x1b[0m \x1b[1m${target}\x1b[0m`);
 }
 
-export function down() {
+export function down(flags = {}) {
+  const dryRun = flags['dry-run'];
   const current = git.currentBranch();
   if (!current) throw new Error('Not on a branch (detached HEAD).');
 
@@ -33,6 +56,10 @@ export function down() {
     throw new Error('Already at bottom of stack (not tracked or no parent).');
   }
 
+  if (dryRun) {
+    console.log(`\x1b[33m~\x1b[0m Would checkout \x1b[1m${parent}\x1b[0m`);
+    return;
+  }
   git.checkout(parent);
   console.log(`\x1b[32m✓\x1b[0m \x1b[1m${parent}\x1b[0m`);
 }

--- a/cli/commands/restack.mjs
+++ b/cli/commands/restack.mjs
@@ -3,6 +3,15 @@
 import * as git from '../git.mjs';
 import { buildStackTree, findStackFor, walkDFS, printTree } from '../stack.mjs';
 
+export const spec = {
+  name: 'restack',
+  summary: 'Locally rebase stack branches onto their parents',
+  usage: 'st restack [--dry-run]',
+  flags: {
+    'dry-run': { description: 'Show what would be rebased without modifying branches' },
+  },
+};
+
 export async function restack(flags) {
   const dryRun = flags['dry-run'];
 

--- a/cli/commands/restack.mjs
+++ b/cli/commands/restack.mjs
@@ -43,49 +43,54 @@ export async function restack(flags) {
     if (mb) mergeBases.set(node.branch, mb);
   });
 
-  // DFS rebase: parent before children
+  // DFS rebase: parent before children. Any exception inside the walk must
+  // not leave the user stranded on an intermediate branch, so the restore is
+  // in a finally block.
   const results = [];
   const originalBranch = current;
 
-  walkDFS(stack, (node, parent) => {
-    if (!parent) return; // skip root
+  try {
+    walkDFS(stack, (node, parent) => {
+      if (!parent) return; // skip root
 
-    const mb = mergeBases.get(node.branch);
-    if (!mb) {
-      results.push({ branch: node.branch, pr: node.pr, status: 'no-merge-base' });
-      return;
+      const mb = mergeBases.get(node.branch);
+      if (!mb) {
+        results.push({ branch: node.branch, pr: node.pr, status: 'no-merge-base' });
+        return;
+      }
+
+      const parentRef = `origin/${parent.branch}`;
+      const remoteChild = git.remoteSha(node.branch);
+      const parentSha = git.remoteSha(parent.branch);
+
+      if (remoteChild && mb === parentSha) {
+        results.push({ branch: node.branch, pr: node.pr, status: 'up-to-date' });
+        return;
+      }
+
+      if (dryRun) {
+        results.push({ branch: node.branch, pr: node.pr, status: 'would-restack', parent: parent.branch });
+        return;
+      }
+
+      git.ensureLocalBranch(node.branch);
+
+      const r = git.rebaseOnto(parentRef, mb, node.branch);
+      if (r.ok) {
+        try {
+          git.pushForce(node.branch);
+          results.push({ branch: node.branch, pr: node.pr, status: 'restacked', parent: parent.branch });
+        } catch (e) {
+          results.push({ branch: node.branch, pr: node.pr, status: 'push-failed', parent: parent.branch, error: e.message.split('\n')[0] });
+        }
+      } else {
+        results.push({ branch: node.branch, pr: node.pr, status: 'conflict', parent: parent.branch, error: r.error });
+      }
+    });
+  } finally {
+    if (!dryRun) {
+      try { git.checkout(originalBranch); } catch {}
     }
-
-    const parentRef = `origin/${parent.branch}`;
-    const remoteChild = git.remoteSha(node.branch);
-    const parentSha = git.remoteSha(parent.branch);
-
-    // Check if restack is needed
-    if (remoteChild && mb === parentSha) {
-      results.push({ branch: node.branch, pr: node.pr, status: 'up-to-date' });
-      return;
-    }
-
-    if (dryRun) {
-      results.push({ branch: node.branch, pr: node.pr, status: 'would-restack', parent: parent.branch });
-      return;
-    }
-
-    // Ensure local branch exists
-    git.ensureLocalBranch(node.branch);
-
-    const r = git.rebaseOnto(parentRef, mb, node.branch);
-    if (r.ok) {
-      git.pushForce(node.branch);
-      results.push({ branch: node.branch, pr: node.pr, status: 'restacked', parent: parent.branch });
-    } else {
-      results.push({ branch: node.branch, pr: node.pr, status: 'conflict', parent: parent.branch, error: r.error });
-    }
-  });
-
-  // Restore original branch
-  if (!dryRun) {
-    try { git.checkout(originalBranch); } catch {}
   }
 
   // Print results
@@ -95,6 +100,7 @@ export async function restack(flags) {
     'would-restack': '\x1b[33m~\x1b[0m',
     'up-to-date': '\x1b[90m·\x1b[0m',
     'conflict': '\x1b[31m✗\x1b[0m',
+    'push-failed': '\x1b[31m✗\x1b[0m',
     'no-merge-base': '\x1b[31m?\x1b[0m',
   };
 

--- a/cli/commands/submit.mjs
+++ b/cli/commands/submit.mjs
@@ -3,6 +3,15 @@
 import * as git from '../git.mjs';
 import { buildStackTree, findStackFor, collectDFS, printTree } from '../stack.mjs';
 
+export const spec = {
+  name: 'submit',
+  summary: 'Push branches and create/update PRs',
+  usage: 'st submit [--dry-run]',
+  flags: {
+    'dry-run': { description: 'Show what would be done without pushing or creating PRs' },
+  },
+};
+
 export async function submit(flags) {
   const dryRun = flags['dry-run'];
   const current = git.currentBranch();

--- a/cli/commands/submit.mjs
+++ b/cli/commands/submit.mjs
@@ -11,61 +11,147 @@ export async function submit(flags) {
     throw new Error('Not on a branch (detached HEAD).');
   }
 
-  // Collect tracked chain: walk from current up to root
+  const defBranch = git.defaultBranch();
+
+  if (current === defBranch) {
+    throw new Error(`Cannot submit the default branch (${defBranch}). Check out a feature branch first.`);
+  }
+
+  // Best-effort fetch so stale remote state doesn't cause us to target or push
+  // a merged/deleted branch. Proceed with cached state if offline.
+  const fetched = dryRun ? true : git.fetchBestEffort();
+  if (!fetched) {
+    console.log('\x1b[33m!\x1b[0m fetch failed (offline?) — proceeding with cached remote state');
+  }
+
+  // Caches to avoid repeated `gh` API calls.
+  const openPrCache = new Map();
+  const openPrFor = (branch) => {
+    if (openPrCache.has(branch)) return openPrCache.get(branch);
+    const result = git.ghPrListForBranch(branch);
+    openPrCache.set(branch, result);
+    return result;
+  };
+  const mergedPrCache = new Map();
+  const mergedPrFor = (branch) => {
+    if (mergedPrCache.has(branch)) return mergedPrCache.get(branch);
+    const result = git.ghPrListMergedForBranch(branch);
+    mergedPrCache.set(branch, result);
+    return result;
+  };
+
+  // Hard gate: refuse to push a branch that has already been merged.
+  //
+  // Detection layers:
+  //   1. GitHub: any merged PR with this head branch (primary signal).
+  //   2. Patch-id: all commits already landed on default (`git cherry`).
+  //      Catches rebase/fast-forward merges; does NOT catch squash-merges.
+  //
+  // Both layers must be CONFIDENT (not errored) for us to clear a branch that
+  // doesn't have an open PR. An unknown state fails closed — the red line is
+  // "never push a merged branch", so when we can't tell, we refuse.
+  const canPush = (branch, prs) => {
+    const hasOpenPr = prs.some(p => p.headRefName === branch) || openPrFor(branch).length > 0;
+    if (hasOpenPr) return { ok: true };
+
+    const merged = mergedPrFor(branch);
+    if (!merged.known) {
+      return { ok: false, reason: 'cannot verify merge status (gh unavailable) — refusing to push without open PR' };
+    }
+    if (merged.prs.length > 0) {
+      return { ok: false, reason: `previously merged as PR #${merged.prs[0].number}` };
+    }
+    const landed = git.isLandedOn(`origin/${defBranch}`, branch);
+    if (!landed.known) {
+      return { ok: false, reason: `cannot verify against origin/${defBranch} — refusing to push without open PR` };
+    }
+    if (landed.landed) {
+      return { ok: false, reason: `commits already on ${defBranch}` };
+    }
+    return { ok: true };
+  };
+
+  // Detect already-merged branches for chain construction. Uses the same layers
+  // as canPush but treats "unknown" as merged so we don't include ambiguous
+  // branches in the chain (the later canPush call would refuse them anyway).
+  const isMerged = (branch) => {
+    const merged = mergedPrFor(branch);
+    if (!merged.known || merged.prs.length > 0) return true;
+    const landed = git.isLandedOn(`origin/${defBranch}`, branch);
+    if (!landed.known || landed.landed) return true;
+    return false;
+  };
+
+  // Build chain, skipping over merged parents.
   const chain = [];
+  const visited = new Set();
   let b = current;
-  while (b) {
-    const parent = git.getTrackedParent(b);
-    if (parent) {
-      chain.push(b);
-      b = parent;
-    } else {
-      // b is either default branch (stop) or untracked (include current only)
-      if (b !== git.defaultBranch()) chain.push(b);
+  while (b && b !== defBranch) {
+    if (visited.has(b)) {
+      console.log(`\x1b[33m!\x1b[0m Cycle in tracked parents at ${b}; stopping chain walk`);
       break;
     }
+    visited.add(b);
+
+    const isCurrent = b === current;
+    if (isCurrent) {
+      chain.push(b);
+    } else if (isMerged(b)) {
+      console.log(`\x1b[33m!\x1b[0m Skipping ${b}: already merged`);
+    } else {
+      chain.push(b);
+    }
+
+    const parent = git.getTrackedParent(b);
+    if (!parent) break;
+    b = parent;
   }
   chain.reverse(); // root-first order
 
-  // If no tracked chain, fall back to just the current branch
   if (chain.length === 0) chain.push(current);
 
   // Push current branch first
+  let prs = git.ghPrList();
+  const currentGate = canPush(current, prs);
+  if (!currentGate.ok) {
+    throw new Error(`Refusing to push ${current}: ${currentGate.reason}`);
+  }
   console.log(`Pushing ${current}...`);
   if (!dryRun) {
     git.pushUpstream(current);
   }
 
-  // Discover existing PRs
-  let prs = git.ghPrList();
+  prs = git.ghPrList();
 
-  // Create PRs for each tracked branch in the chain (root → leaf)
-  const defBranch = git.defaultBranch();
+  // Create PRs for each branch in the chain (root → leaf)
   for (const branch of chain) {
-    const existingPr = prs.find(p => p.headRefName === branch);
+    const existingPr = prs.find(p => p.headRefName === branch) || openPrFor(branch)[0];
     if (existingPr) {
       console.log(`  \x1b[90m·\x1b[0m PR #${existingPr.number} already exists for ${branch}`);
       continue;
     }
 
-    const base = git.getTrackedParent(branch) || detectBase(branch, prs);
+    const base = resolveBase(branch, prs, openPrFor, mergedPrFor, defBranch);
     console.log(`Creating PR: ${branch} → ${base}`);
     if (!dryRun) {
+      const gate = canPush(branch, prs);
+      if (!gate.ok) {
+        console.log(`  \x1b[31m✗\x1b[0m Refused to push ${branch}: ${gate.reason}`);
+        continue;
+      }
       git.pushUpstream(branch);
       const title = branchToTitle(branch);
       try {
         const url = git.ghPrCreate(branch, base, title);
         console.log(`  \x1b[32m✓\x1b[0m Created: ${url}`);
-      } catch {
-        // PR creation failed — check if one already exists (possibly by another author)
+      } catch (e) {
         const existing = git.ghPrListForBranch(branch);
         if (existing.length > 0) {
           console.log(`  \x1b[90m·\x1b[0m PR #${existing[0].number} already exists for ${branch}`);
         } else {
-          console.log(`  \x1b[31m✗\x1b[0m Failed to create PR for ${branch}`);
+          console.log(`  \x1b[31m✗\x1b[0m Failed to create PR for ${branch}: ${e.message.split('\n')[0]}`);
         }
       }
-      // Re-fetch so subsequent iterations see the new PR
       prs = git.ghPrList();
     } else {
       console.log(`  \x1b[33m~\x1b[0m Would create PR: ${branch} → ${base}`);
@@ -107,11 +193,16 @@ export async function submit(flags) {
         continue;
       }
 
+      const gate = canPush(node.branch, freshPrs);
+      if (!gate.ok) {
+        results.push({ branch: node.branch, pr: node.pr, status: 'refused', detail: gate.reason });
+        continue;
+      }
       try {
         git.pushForce(node.branch);
         results.push({ branch: node.branch, pr: node.pr, status: 'pushed' });
-      } catch {
-        results.push({ branch: node.branch, pr: node.pr, status: 'push-failed' });
+      } catch (e) {
+        results.push({ branch: node.branch, pr: node.pr, status: 'push-failed', detail: e.message.split('\n')[0] });
       }
     }
 
@@ -142,12 +233,14 @@ export async function submit(flags) {
       'would-push': '\x1b[33m~\x1b[0m',
       'up-to-date': '\x1b[90m·\x1b[0m',
       'push-failed': '\x1b[31m✗\x1b[0m',
+      'refused': '\x1b[31m✗\x1b[0m',
       'no-local': '\x1b[90m-\x1b[0m',
     };
 
     for (const r of results) {
       const i = icon[r.status] || ' ';
-      console.log(`  ${i} \x1b[1m${r.branch}\x1b[0m \x1b[90m#${r.pr}\x1b[0m ${r.status}`);
+      const detail = r.detail ? ` \x1b[90m(${r.detail})\x1b[0m` : '';
+      console.log(`  ${i} \x1b[1m${r.branch}\x1b[0m \x1b[90m#${r.pr}\x1b[0m ${r.status}${detail}`);
     }
 
     console.log('\n\x1b[1mStack:\x1b[0m');
@@ -155,15 +248,42 @@ export async function submit(flags) {
   }
 }
 
-/**
- * Detect the base branch for a new PR.
- * If any open PR's head is an ancestor of the current branch, use that as base.
- * Otherwise, use the default branch.
- */
+// A parent is "usable" as a PR base if:
+//   - it is the default branch,
+//   - it has an open PR (either in the @me-scoped list or repo-wide), or
+//   - its remote ref still exists AND it has not been merged.
+// Merged branches (even if the local ref lingers) are never usable as a base.
+function isUsableParent(parent, prs, openPrFor, mergedPrFor, defBranch) {
+  if (parent === defBranch) return true;
+  if (prs.some(p => p.headRefName === parent)) return true;
+  if (openPrFor(parent).length > 0) return true;
+  const merged = mergedPrFor(parent);
+  if (merged.known && merged.prs.length > 0) return false;
+  const landed = git.isLandedOn(`origin/${defBranch}`, parent);
+  if (landed.known && landed.landed) return false;
+  if (git.remoteSha(parent)) return true;
+  return false;
+}
+
+// Resolve the PR base for `branch` by walking the tracked-parent chain past any
+// stale entries until we find a usable parent, falling back to ancestor
+// detection and finally the default branch.
+function resolveBase(branch, prs, openPrFor, mergedPrFor, defBranch) {
+  let parent = git.getTrackedParent(branch);
+  const seen = new Set([branch]);
+  while (parent) {
+    if (seen.has(parent)) break; // cycle
+    seen.add(parent);
+    if (isUsableParent(parent, prs, openPrFor, mergedPrFor, defBranch)) return parent;
+    console.log(`\x1b[33m!\x1b[0m Ignoring stale tracked parent ${parent} (merged or deleted); walking up`);
+    parent = git.getTrackedParent(parent);
+  }
+  return detectBase(branch, prs) || defBranch;
+}
+
+// Fallback: find an ancestor PR branch whose tip is reachable from `branch`.
 function detectBase(branch, prs) {
   const defBranch = git.defaultBranch();
-
-  // Collect all PR branches that are ancestors of the current branch
   let best = null;
   let bestDistance = Infinity;
 
@@ -171,7 +291,6 @@ function detectBase(branch, prs) {
     const mb = git.mergeBase(pr.headRefName, branch);
     const prSha = git.localSha(pr.headRefName) || git.remoteSha(pr.headRefName);
     if (mb && prSha && mb === prSha) {
-      // Count commits between this ancestor and the branch to find the closest one
       const distance = git.commitDistance(prSha, branch);
       if (distance < bestDistance) {
         best = pr.headRefName;

--- a/cli/commands/submit.mjs
+++ b/cli/commands/submit.mjs
@@ -48,34 +48,87 @@ export async function submit(flags) {
     mergedPrCache.set(branch, result);
     return result;
   };
+  const anyStateCache = new Map();
+  const anyStatePrFor = (branch) => {
+    if (anyStateCache.has(branch)) return anyStateCache.get(branch);
+    const result = git.ghPrListAnyStateForBranch(branch);
+    anyStateCache.set(branch, result);
+    return result;
+  };
+  const originRepo = git.originRepo();
 
-  // Hard gate: refuse to push a branch that has already been merged.
-  //
-  // Detection layers:
-  //   1. GitHub: any merged PR with this head branch (primary signal).
-  //   2. Patch-id: all commits already landed on default (`git cherry`).
-  //      Catches rebase/fast-forward merges; does NOT catch squash-merges.
-  //
-  // Both layers must be CONFIDENT (not errored) for us to clear a branch that
-  // doesn't have an open PR. An unknown state fails closed — the red line is
-  // "never push a merged branch", so when we can't tell, we refuse.
-  const canPush = (branch, prs) => {
-    const hasOpenPr = prs.some(p => p.headRefName === branch) || openPrFor(branch).length > 0;
-    if (hasOpenPr) return { ok: true };
+  // A PR "belongs to this repo" if its head ref lives in the same remote we
+  // push to. Fork PRs point at a different head repository — treating such a
+  // PR as ownership of `origin/<branch>` would let us push over an unrelated
+  // branch in the upstream repo. Unknown head-repo metadata is treated as
+  // same-repo (gh may omit it for older response shapes) — the other gates
+  // still apply.
+  const isSameRepoPr = (pr) => {
+    if (!originRepo) return true;
+    const headOwner = pr.headRepositoryOwner && pr.headRepositoryOwner.login;
+    const headName = pr.headRepository && pr.headRepository.name;
+    if (!headOwner || !headName) return true;
+    return headOwner === originRepo.owner && headName === originRepo.name;
+  };
 
-    const merged = mergedPrFor(branch);
-    if (!merged.known) {
-      return { ok: false, reason: 'cannot verify merge status (gh unavailable) — refusing to push without open PR' };
-    }
-    if (merged.prs.length > 0) {
-      return { ok: false, reason: `previously merged as PR #${merged.prs[0].number}` };
-    }
+  // Hard gate: refuse to push a branch that has already been merged OR that
+  // we don't own.
+  //
+  // Checks (order matters):
+  //   1. Patch-id landed check — if every commit on `branch` beyond
+  //      origin/<default> is already present there, pushing adds nothing and
+  //      could re-introduce merged content. Refuse. Unknown → refuse.
+  //   2. Stale-local-vs-merged check — if a merged PR for this branch exists
+  //      and its head SHA at merge time matches our local tip, the branch
+  //      was never advanced past the merge. Refuse.
+  //   3. Ownership check — only clear the gate when there's an open PR for
+  //      this branch authored by the current user (`prs` is @me-scoped).
+  //      A teammate's open PR does NOT authorize us to push their branch.
+  //   4. Brand-new branch — no open or merged PRs. Allow.
+  //
+  // Unknown state (gh or git errors) fails closed when the branch has no
+  // current-user open PR.
+  const canPush = (branch, myPrs) => {
     const landed = git.isLandedOn(`origin/${defBranch}`, branch);
     if (!landed.known) {
-      return { ok: false, reason: `cannot verify against origin/${defBranch} — refusing to push without open PR` };
+      return { ok: false, reason: `cannot verify against origin/${defBranch}` };
     }
     if (landed.landed) {
       return { ok: false, reason: `commits already on ${defBranch}` };
+    }
+
+    const merged = mergedPrFor(branch);
+    if (!merged.known) {
+      return { ok: false, reason: 'cannot verify merge status (gh unavailable)' };
+    }
+    const localTip = git.localSha(branch);
+    for (const mpr of merged.prs) {
+      if (localTip && (mpr.headRefOid === localTip || (mpr.mergeCommit && mpr.mergeCommit.oid === localTip))) {
+        return { ok: false, reason: `local tip matches merged PR #${mpr.number}` };
+      }
+    }
+
+    const hasMyOpenPr = myPrs.some(p => p.headRefName === branch && isSameRepoPr(p));
+    if (hasMyOpenPr) return { ok: true };
+
+    // No current-user open PR in this repo. Require positive ownership:
+    // the branch must have NO foreign PR history. A PR authored by someone
+    // else — or our own PR pointing at a fork head — blocks us, since the
+    // branch may still exist on origin and a force-push would rewrite it.
+    const anyState = anyStatePrFor(branch);
+    if (!anyState.known) {
+      return { ok: false, reason: 'cannot verify PR history (gh unavailable)' };
+    }
+    const me = git.ghCurrentUser();
+    const foreign = anyState.prs.find(p => {
+      const authored = me && p.author && p.author.login === me;
+      return p.state !== 'MERGED' && (!authored || !isSameRepoPr(p));
+    });
+    if (foreign) {
+      return { ok: false, reason: `PR #${foreign.number} (${foreign.state.toLowerCase()}) is not yours — not authorized to push` };
+    }
+    if (merged.prs.length > 0) {
+      return { ok: false, reason: `previously merged as PR #${merged.prs[0].number}` };
     }
     return { ok: true };
   };
@@ -167,8 +220,12 @@ export async function submit(flags) {
     }
   }
 
-  // Re-fetch PR list after potential creation, including PRs by other authors for tracked branches
-  let freshPrs = dryRun ? prs : git.ghPrList();
+  // Re-fetch the user's own PRs (canonical source for push authorization).
+  // Separately build a discovery-only tree that includes teammate PRs so the
+  // stack shape is accurate, but never use the discovery tree to decide
+  // whether to push — that must go through canPush with myPrs only.
+  const myPrs = dryRun ? prs : git.ghPrList();
+  const freshPrs = [...myPrs];
   for (const branch of chain) {
     if (!freshPrs.find(p => p.headRefName === branch)) {
       const others = git.ghPrListForBranch(branch);
@@ -202,7 +259,7 @@ export async function submit(flags) {
         continue;
       }
 
-      const gate = canPush(node.branch, freshPrs);
+      const gate = canPush(node.branch, myPrs);
       if (!gate.ok) {
         results.push({ branch: node.branch, pr: node.pr, status: 'refused', detail: gate.reason });
         continue;

--- a/cli/commands/sync.mjs
+++ b/cli/commands/sync.mjs
@@ -1,17 +1,30 @@
 // st sync — Sync local branches with remote after Actions restack.
 
+import readline from 'node:readline';
 import * as git from '../git.mjs';
 import { buildStackTree, printTree } from '../stack.mjs';
 
 export const spec = {
   name: 'sync',
   summary: 'Sync local branches with remote (after Actions restack)',
-  usage: 'st sync [--dry-run] [--prune]',
+  usage: 'st sync [--dry-run] [--prune | --no-prune]',
   flags: {
     'dry-run': { description: 'Show what would be done without modifying branches' },
-    'prune': { description: 'Also delete local branches whose remote tracking branch is gone' },
+    'prune': { description: 'Auto-delete tracked local branches whose remote is gone (skip the prompt)' },
+    'no-prune': { description: 'Skip pruning entirely (default is to prompt)' },
   },
 };
+
+async function promptYesNo(question) {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await new Promise(resolve => rl.question(question, resolve));
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
+}
 
 export async function sync(flags) {
   const dryRun = flags['dry-run'];
@@ -71,18 +84,40 @@ export async function sync(flags) {
   // Prune: staqd-tracked local branches whose remote is gone AND whose PR
   // is no longer open (typical signal of a merged stacked branch). Scoped to
   // tracked branches so we never delete a user's untracked local work.
-  if (flags.prune) {
+  //
+  // Mode:
+  //   --prune    → auto-delete without asking
+  //   --no-prune → skip entirely
+  //   (default)  → prompt "Delete local branch X? [y/N]" per branch (TTY only)
+  if (!flags['no-prune']) {
     const tracked = git.listTrackedBranches();
     const trackedBranchNames = new Set(tracked.map(t => t.branch));
     const prBranches = new Set(prs.map(p => p.headRefName));
+
+    const candidates = [];
     for (const branch of trackedBranchNames) {
       if (branch === current || branch === git.defaultBranch()) continue;
       if (prBranches.has(branch)) continue;
-      const remote = git.remoteSha(branch);
-      if (remote) continue;
+      if (git.remoteSha(branch)) continue;
+      candidates.push(branch);
+    }
+
+    for (const branch of candidates) {
       if (dryRun) {
         results.push({ branch, status: 'would-prune' });
         continue;
+      }
+      let confirmed = !!flags.prune;
+      if (!confirmed) {
+        if (!process.stdin.isTTY) {
+          results.push({ branch, status: 'prune-skipped', detail: 'non-interactive; use --prune to auto-delete' });
+          continue;
+        }
+        confirmed = await promptYesNo(`Delete local branch \x1b[1m${branch}\x1b[0m (remote gone)? [y/N] `);
+        if (!confirmed) {
+          results.push({ branch, status: 'prune-skipped', detail: 'user declined' });
+          continue;
+        }
       }
       const deleted = git.deleteBranch(branch);
       git.unsetTrackedParent(branch);
@@ -90,7 +125,8 @@ export async function sync(flags) {
     }
 
     // Also unset tracked-parent config that points at a branch no longer
-    // present anywhere (merged-and-deleted parents).
+    // present anywhere (merged-and-deleted parents). Always safe to clean
+    // up — no branch deletion, just config.
     for (const { branch, parent } of tracked) {
       if (parent === git.defaultBranch()) continue;
       if (trackedBranchNames.has(parent)) continue;
@@ -114,6 +150,7 @@ export async function sync(flags) {
     'dirty': '\x1b[31m✗\x1b[0m',
     'pruned': '\x1b[33m✂\x1b[0m',
     'would-prune': '\x1b[33m✂\x1b[0m',
+    'prune-skipped': '\x1b[90m·\x1b[0m',
     'unset-parent': '\x1b[33m✂\x1b[0m',
     'would-unset-parent': '\x1b[33m✂\x1b[0m',
     'no-local': '\x1b[90m-\x1b[0m',

--- a/cli/commands/sync.mjs
+++ b/cli/commands/sync.mjs
@@ -3,6 +3,16 @@
 import * as git from '../git.mjs';
 import { buildStackTree, printTree } from '../stack.mjs';
 
+export const spec = {
+  name: 'sync',
+  summary: 'Sync local branches with remote (after Actions restack)',
+  usage: 'st sync [--dry-run] [--prune]',
+  flags: {
+    'dry-run': { description: 'Show what would be done without modifying branches' },
+    'prune': { description: 'Also delete local branches whose remote tracking branch is gone' },
+  },
+};
+
 export async function sync(flags) {
   const dryRun = flags['dry-run'];
 

--- a/cli/commands/sync.mjs
+++ b/cli/commands/sync.mjs
@@ -68,22 +68,40 @@ export async function sync(flags) {
     results.push({ branch, pr: pr.number, status: 'synced', detail: `${local.slice(0, 7)} → ${remote.slice(0, 7)}` });
   }
 
-  // Prune: local branches whose remote tracking branch is gone (merged PRs)
+  // Prune: staqd-tracked local branches whose remote is gone AND whose PR
+  // is no longer open (typical signal of a merged stacked branch). Scoped to
+  // tracked branches so we never delete a user's untracked local work.
   if (flags.prune) {
-    const locals = git.localBranches();
+    const tracked = git.listTrackedBranches();
+    const trackedBranchNames = new Set(tracked.map(t => t.branch));
     const prBranches = new Set(prs.map(p => p.headRefName));
-    for (const branch of locals) {
+    for (const branch of trackedBranchNames) {
       if (branch === current || branch === git.defaultBranch()) continue;
       if (prBranches.has(branch)) continue;
       const remote = git.remoteSha(branch);
-      if (!remote) {
-        if (dryRun) {
-          results.push({ branch, status: 'would-prune' });
-        } else {
-          const deleted = git.deleteBranch(branch);
-          results.push({ branch, status: deleted !== null ? 'pruned' : 'prune-failed' });
-        }
+      if (remote) continue;
+      if (dryRun) {
+        results.push({ branch, status: 'would-prune' });
+        continue;
       }
+      const deleted = git.deleteBranch(branch);
+      git.unsetTrackedParent(branch);
+      results.push({ branch, status: deleted !== null ? 'pruned' : 'prune-failed' });
+    }
+
+    // Also unset tracked-parent config that points at a branch no longer
+    // present anywhere (merged-and-deleted parents).
+    for (const { branch, parent } of tracked) {
+      if (parent === git.defaultBranch()) continue;
+      if (trackedBranchNames.has(parent)) continue;
+      if (git.remoteSha(parent)) continue;
+      if (prBranches.has(parent)) continue;
+      if (dryRun) {
+        results.push({ branch, status: 'would-unset-parent', detail: `parent ${parent} is gone` });
+        continue;
+      }
+      git.unsetTrackedParent(branch);
+      results.push({ branch, status: 'unset-parent', detail: `cleared stale parent ${parent}` });
     }
   }
 
@@ -96,6 +114,8 @@ export async function sync(flags) {
     'dirty': '\x1b[31m✗\x1b[0m',
     'pruned': '\x1b[33m✂\x1b[0m',
     'would-prune': '\x1b[33m✂\x1b[0m',
+    'unset-parent': '\x1b[33m✂\x1b[0m',
+    'would-unset-parent': '\x1b[33m✂\x1b[0m',
     'no-local': '\x1b[90m-\x1b[0m',
     'prune-failed': '\x1b[31m✗\x1b[0m',
   };

--- a/cli/commands/track.mjs
+++ b/cli/commands/track.mjs
@@ -16,6 +16,9 @@ export function track(flags) {
     throw new Error(`Cannot track the default branch (${defBranch}).`);
   }
 
+  if (flags.parent === true) {
+    throw new Error('--parent requires a value, e.g. --parent=main');
+  }
   const parent = flags.parent || detectParent(current);
 
   // Validate parent chain reaches default branch

--- a/cli/commands/track.mjs
+++ b/cli/commands/track.mjs
@@ -42,9 +42,17 @@ export function track(flags) {
   }
   const parent = flags.parent || detectParent(current);
 
-  if (!validateParent(parent)) {
+  if (parent === current) {
+    throw new Error(`Cannot track "${current}" onto itself.`);
+  }
+
+  // Include the pending edge (current -> parent) so a proposed assignment
+  // that would close a cycle is caught. Without this, tracking C -> A when
+  // A -> B -> C already exists would loop through config.
+  if (!validateParent(parent, current)) {
     throw new Error(
-      `Cannot track: parent "${parent}" is not tracked and does not reach ${defBranch}.\n` +
+      `Cannot track: parent "${parent}" is not tracked and does not reach ${defBranch}, ` +
+      `or the chain contains a cycle.\n` +
       `Either track "${parent}" first, or use --parent to specify a valid parent.`
     );
   }
@@ -95,48 +103,52 @@ function listTracked() {
   }
 }
 
-/**
- * Detect the parent for the current branch.
- * Finds the closest tracked ancestor or the default branch.
- */
+// Detect the closest tracked ancestor of `branch`. A tracked branch T is a
+// plausible parent if its merge-base with `branch` sits above the default
+// branch's history — i.e. T and `branch` share private work, not just main.
+// Among candidates, pick the one with the smallest commit distance.
+//
+// This is more forgiving than requiring T's tip SHA to equal the merge-base,
+// which breaks whenever T advances (e.g. after st sync).
 function detectParent(branch) {
   const defBranch = git.defaultBranch();
+  const defSha = git.remoteSha(defBranch) || git.localSha(defBranch);
   const tracked = git.listTrackedBranches();
 
-  // Check tracked branches that are ancestors of the current branch
   let best = null;
   let bestDistance = Infinity;
 
   for (const { branch: trackedBranch } of tracked) {
+    if (trackedBranch === branch) continue;
     const mb = git.mergeBase(trackedBranch, branch);
-    const sha = git.localSha(trackedBranch);
-    if (mb && sha && mb === sha) {
-      const distance = git.commitDistance(sha, branch);
-      if (distance < bestDistance) {
-        best = trackedBranch;
-        bestDistance = distance;
-      }
+    if (!mb) continue;
+    // Skip if the only shared history is the default branch — means T was
+    // never an ancestor of `branch`.
+    if (defSha && git.isAncestor(mb, defSha)) continue;
+    const distance = git.commitDistance(mb, branch);
+    if (distance < bestDistance) {
+      best = trackedBranch;
+      bestDistance = distance;
     }
   }
 
   return best || defBranch;
 }
 
-/**
- * Validate that a parent is either the default branch or a tracked branch
- * whose chain reaches the default branch.
- */
-function validateParent(parent) {
+// Validate that assigning `child -> parent` would produce a chain that
+// terminates at the default branch without forming a cycle.
+function validateParent(parent, child) {
   const defBranch = git.defaultBranch();
   if (parent === defBranch) return true;
 
-  let b = parent;
   const visited = new Set();
+  if (child) visited.add(child); // reject cycles through the pending edge
+  let b = parent;
   while (b) {
-    if (visited.has(b)) return false; // cycle protection
+    if (visited.has(b)) return false;
     visited.add(b);
     const p = git.getTrackedParent(b);
-    if (!p) return false;  // chain broken
+    if (!p) return false;
     if (p === defBranch) return true;
     b = p;
   }

--- a/cli/commands/track.mjs
+++ b/cli/commands/track.mjs
@@ -2,12 +2,33 @@
 
 import * as git from '../git.mjs';
 
+export const trackSpec = {
+  name: 'track',
+  summary: 'Register current branch in the stack',
+  usage: 'st track [--parent=<branch>] [--list] [--dry-run]',
+  flags: {
+    'parent': { description: 'Parent branch name (defaults to auto-detected ancestor)', requiresValue: true },
+    'list': { description: 'List all tracked branches' },
+    'dry-run': { description: 'Show what would be tracked without writing git config' },
+  },
+};
+
+export const untrackSpec = {
+  name: 'untrack',
+  summary: 'Remove current branch from the stack',
+  usage: 'st untrack [--dry-run]',
+  flags: {
+    'dry-run': { description: 'Show what would be untracked without writing git config' },
+  },
+};
+
 export function track(flags) {
   if (flags.list) {
     listTracked();
     return;
   }
 
+  const dryRun = flags['dry-run'];
   const current = git.currentBranch();
   if (!current) throw new Error('Not on a branch (detached HEAD).');
 
@@ -21,7 +42,6 @@ export function track(flags) {
   }
   const parent = flags.parent || detectParent(current);
 
-  // Validate parent chain reaches default branch
   if (!validateParent(parent)) {
     throw new Error(
       `Cannot track: parent "${parent}" is not tracked and does not reach ${defBranch}.\n` +
@@ -29,17 +49,28 @@ export function track(flags) {
     );
   }
 
+  if (dryRun) {
+    console.log(`\x1b[33m~\x1b[0m Would track \x1b[1m${current}\x1b[0m → \x1b[1m${parent}\x1b[0m`);
+    return;
+  }
+
   git.setTrackedParent(current, parent);
   console.log(`\x1b[32m✓\x1b[0m Tracking \x1b[1m${current}\x1b[0m → \x1b[1m${parent}\x1b[0m`);
 }
 
-export function untrack() {
+export function untrack(flags = {}) {
+  const dryRun = flags['dry-run'];
   const current = git.currentBranch();
   if (!current) throw new Error('Not on a branch (detached HEAD).');
 
   const parent = git.getTrackedParent(current);
   if (!parent) {
     console.log(`\x1b[90m·\x1b[0m ${current} is not tracked`);
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`\x1b[33m~\x1b[0m Would untrack \x1b[1m${current}\x1b[0m (current parent: ${parent})`);
     return;
   }
 

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -43,6 +43,30 @@ export function fetch() {
   run('git', ['fetch', '--prune', 'origin']);
 }
 
+// Best-effort fetch: returns true on success, false on failure (offline, auth, etc).
+// Never throws. Use when stale remote state is tolerable but desired.
+export function fetchBestEffort() {
+  const out = run('git', ['fetch', '--prune', 'origin'], { silent: true });
+  return out !== null;
+}
+
+// Checks whether every commit reachable from `branch` but not from `base` has
+// an equivalent patch already on `base`.
+// Returns:
+//   { known: true, landed: true }  — all commits already on base, or branch has
+//                                     no commits beyond base
+//   { known: true, landed: false } — at least one commit not on base
+//   { known: false }               — cherry errored (missing ref, etc.)
+// Note: patch-id equivalence. Does NOT detect squash-merges (squashing
+// combines patch-ids so individual commits no longer match).
+export function isLandedOn(base, branch) {
+  const out = run('git', ['cherry', base, branch], { silent: true });
+  if (out === null) return { known: false };
+  const lines = out.split('\n').filter(Boolean);
+  if (lines.length === 0) return { known: true, landed: true };
+  return { known: true, landed: lines.every(l => l.startsWith('-')) };
+}
+
 export function localBranches() {
   const out = run('git', ['branch', '--format=%(refname:short)'], { silent: true });
   return out ? out.split('\n').filter(Boolean) : [];
@@ -173,6 +197,25 @@ export function ghPrListForBranch(branch) {
   );
   if (!out) return [];
   return JSON.parse(out);
+}
+
+// Returns merged PRs for `branch` (state=merged).
+// Returns:
+//   { known: true, prs: [...] } — gh succeeded, list may be empty
+//   { known: false }            — gh errored (unauth, offline, rate limit)
+export function ghPrListMergedForBranch(branch) {
+  const out = run(
+    'gh', ['pr', 'list', '--head', branch, '--state', 'merged',
+           '--json', 'number,headRefName,mergedAt,url'],
+    { silent: true },
+  );
+  if (out === null) return { known: false };
+  if (!out) return { known: true, prs: [] };
+  try {
+    return { known: true, prs: JSON.parse(out) };
+  } catch {
+    return { known: false };
+  }
 }
 
 export function ghPrEditBase(number, base) {

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -39,14 +39,19 @@ export function isClean() {
   return cached !== null;
 }
 
-export function fetch() {
-  run('git', ['fetch', '--prune', 'origin']);
+export function fetch({ silent = false } = {}) {
+  if (silent) {
+    run('git', ['fetch', '--prune', '--quiet', 'origin'], { silent: true });
+  } else {
+    run('git', ['fetch', '--prune', 'origin']);
+  }
 }
 
 // Best-effort fetch: returns true on success, false on failure (offline, auth, etc).
-// Never throws. Use when stale remote state is tolerable but desired.
+// Never throws. Always quiet on stderr. Use when stale remote state is
+// tolerable but desired.
 export function fetchBestEffort() {
-  const out = run('git', ['fetch', '--prune', 'origin'], { silent: true });
+  const out = run('git', ['fetch', '--prune', '--quiet', 'origin'], { silent: true });
   return out !== null;
 }
 

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -84,6 +84,16 @@ export function mergeBase(a, b) {
   return run('git', ['merge-base', a, b], { silent: true });
 }
 
+// True if `ancestor` is an ancestor (or equal) of `descendant`. False on error.
+export function isAncestor(ancestor, descendant) {
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', ancestor, descendant], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function commitDistance(from, to) {
   const out = run('git', ['rev-list', '--count', `${from}..${to}`], { silent: true });
   return out ? Number(out) : Infinity;
@@ -163,10 +173,26 @@ export function listTrackedBranches() {
 
 // ── gh CLI helpers ──
 
+// Open PRs authored by the current user. Used by push paths so we never
+// attempt to force-push a teammate's branch. For stack tree DISCOVERY that
+// may include teammate PRs, use `ghPrListAll()` instead — but never feed its
+// output into push paths.
 export function ghPrList() {
   const out = run(
-    'gh', ['pr', 'list', '--author', '@me', '--state', 'open',
+    'gh', ['pr', 'list', '--author', '@me', '--state', 'open', '--limit', '500',
            '--json', 'number,headRefName,baseRefName,title,url'],
+    { silent: true },
+  );
+  if (!out) return [];
+  return JSON.parse(out);
+}
+
+// Repo-wide open PR list (all authors). Safe for READ-ONLY stack tree
+// construction. Must NOT be used to drive push/force-push decisions.
+export function ghPrListAll() {
+  const out = run(
+    'gh', ['pr', 'list', '--state', 'open', '--limit', '500',
+           '--json', 'number,headRefName,baseRefName,title,url,author'],
     { silent: true },
   );
   if (!out) return [];

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -182,14 +182,58 @@ export function listTrackedBranches() {
 // attempt to force-push a teammate's branch. For stack tree DISCOVERY that
 // may include teammate PRs, use `ghPrListAll()` instead — but never feed its
 // output into push paths.
+//
+// headRepository/headRepositoryOwner are included so callers can distinguish
+// PRs from the same-repo (safe to treat as ownership of `origin/<branch>`)
+// from fork PRs (whose head lives in a different repo).
 export function ghPrList() {
   const out = run(
     'gh', ['pr', 'list', '--author', '@me', '--state', 'open', '--limit', '500',
-           '--json', 'number,headRefName,baseRefName,title,url'],
+           '--json', 'number,headRefName,baseRefName,title,url,headRepository,headRepositoryOwner'],
     { silent: true },
   );
   if (!out) return [];
   return JSON.parse(out);
+}
+
+// Repo-wide PR list for `branch` across all states. Used by push paths to
+// refuse force-pushing a branch that has any non-current-user PR history
+// (open, closed-unmerged) — the branch may be a teammate's abandoned work.
+// Returns { known, prs } same as ghPrListMergedForBranch.
+export function ghPrListAnyStateForBranch(branch) {
+  const out = run(
+    'gh', ['pr', 'list', '--head', branch, '--state', 'all', '--limit', '100',
+           '--json', 'number,state,headRefName,author,url,headRepository,headRepositoryOwner'],
+    { silent: true },
+  );
+  if (out === null) return { known: false };
+  if (!out) return { known: true, prs: [] };
+  try {
+    return { known: true, prs: JSON.parse(out) };
+  } catch {
+    return { known: false };
+  }
+}
+
+// The owner/name of the origin remote, parsed from its URL. Used to decide
+// whether a PR's head repo is this repo (safe for push) or a fork.
+// Returns { owner, name } or null.
+export function originRepo() {
+  const url = run('git', ['remote', 'get-url', 'origin'], { silent: true });
+  if (!url) return null;
+  // Supports https://github.com/OWNER/NAME(.git)? and git@github.com:OWNER/NAME(.git)?
+  const m = url.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+  if (!m) return null;
+  return { owner: m[1], name: m[2] };
+}
+
+// The current GitHub user's login, or null on failure. Cached at module load.
+let _currentUserCache;
+export function ghCurrentUser() {
+  if (_currentUserCache !== undefined) return _currentUserCache;
+  const out = run('gh', ['api', 'user', '--jq', '.login'], { silent: true });
+  _currentUserCache = out || null;
+  return _currentUserCache;
 }
 
 // Repo-wide open PR list (all authors). Safe for READ-ONLY stack tree
@@ -232,12 +276,15 @@ export function ghPrListForBranch(branch) {
 
 // Returns merged PRs for `branch` (state=merged).
 // Returns:
-//   { known: true, prs: [...] } — gh succeeded, list may be empty
+//   { known: true, prs: [...] } — gh succeeded, list may be empty.
+//                                 Each PR includes mergeCommit.oid when
+//                                 available so callers can detect stale
+//                                 local branches pointing at merged content.
 //   { known: false }            — gh errored (unauth, offline, rate limit)
 export function ghPrListMergedForBranch(branch) {
   const out = run(
     'gh', ['pr', 'list', '--head', branch, '--state', 'merged',
-           '--json', 'number,headRefName,mergedAt,url'],
+           '--json', 'number,headRefName,mergedAt,url,mergeCommit,headRefOid'],
     { silent: true },
   );
   if (out === null) return { known: false };

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -1,64 +1,139 @@
-import { sync } from './commands/sync.mjs';
-import { restack } from './commands/restack.mjs';
-import { submit } from './commands/submit.mjs';
-import { move } from './commands/move.mjs';
-import { track, untrack } from './commands/track.mjs';
-import { create } from './commands/create.mjs';
-import { log } from './commands/log.mjs';
-import { up, down } from './commands/navigate.mjs';
+import { sync, spec as syncSpec } from './commands/sync.mjs';
+import { restack, spec as restackSpec } from './commands/restack.mjs';
+import { submit, spec as submitSpec } from './commands/submit.mjs';
+import { move, spec as moveSpec } from './commands/move.mjs';
+import { track, untrack, trackSpec, untrackSpec } from './commands/track.mjs';
+import { create, spec as createSpec } from './commands/create.mjs';
+import { log, spec as logSpec } from './commands/log.mjs';
+import { up, down, upSpec, downSpec } from './commands/navigate.mjs';
 
-const COMMANDS = { sync, restack, submit, move, track, untrack, create, log, up, down };
-
-const HELP = `\x1b[1mstaqd\x1b[0m — Stacked PR CLI
-
-\x1b[1mUSAGE\x1b[0m
-  st <command> [options]
-
-\x1b[1mCOMMANDS\x1b[0m
-  sync       Sync local branches with remote (after Actions restack)
-  restack    Locally rebase stack branches onto their parents
-  submit     Push branches and create/update PRs
-  move       Move current branch to a new parent
-  track      Register current branch in the stack (--parent, --list)
-  untrack    Remove current branch from the stack
-  create     Create a new branch and auto-track it
-  log        Visualize the tracked stack tree
-  up         Move to child branch in the stack
-  down       Move to parent branch in the stack
-
-\x1b[1mOPTIONS\x1b[0m
-  --help     Show help
-  --dry-run  Show what would be done without making changes`;
+const COMMANDS = {
+  sync:    { handler: sync,    spec: syncSpec },
+  restack: { handler: restack, spec: restackSpec },
+  submit:  { handler: submit,  spec: submitSpec },
+  move:    { handler: move,    spec: moveSpec },
+  track:   { handler: track,   spec: trackSpec },
+  untrack: { handler: untrack, spec: untrackSpec },
+  create:  { handler: create,  spec: createSpec },
+  log:     { handler: log,     spec: logSpec },
+  up:      { handler: up,      spec: upSpec },
+  down:    { handler: down,    spec: downSpec },
+};
 
 export async function run(args) {
   const command = args[0];
 
-  if (!command || command === '--help' || command === 'help') {
-    console.log(HELP);
+  if (!command || command === '--help' || command === '-h' || command === 'help') {
+    printGlobalHelp();
     return;
   }
 
-  const handler = COMMANDS[command];
-  if (!handler) {
+  const entry = COMMANDS[command];
+  if (!entry) {
     console.error(`Unknown command: ${command}\n`);
-    console.log(HELP);
+    printGlobalHelp();
     process.exit(1);
   }
 
-  const flags = parseFlags(args.slice(1));
-  await handler(flags);
+  const rest = args.slice(1);
+  if (rest.includes('--help') || rest.includes('-h')) {
+    printCommandHelp(entry.spec);
+    return;
+  }
+
+  const flags = parseFlags(rest);
+  validateFlags(flags, entry.spec);
+  await entry.handler(flags);
 }
 
 function parseFlags(args) {
   const flags = { _: [] };
   for (const arg of args) {
     if (arg.startsWith('--')) {
-      const [key, val] = arg.slice(2).split('=');
-      flags[key] = val ?? true;
+      const rest = arg.slice(2);
+      const eq = rest.indexOf('=');
+      if (eq === -1) {
+        flags[rest] = true;
+      } else {
+        flags[rest.slice(0, eq)] = rest.slice(eq + 1);
+      }
     } else {
       flags._.push(arg);
     }
   }
   return flags;
 }
-// feature C
+
+function validateFlags(flags, spec) {
+  const allowed = new Set(Object.keys(spec.flags || {}));
+  for (const key of Object.keys(flags)) {
+    if (key === '_') continue;
+    if (!allowed.has(key)) {
+      const hint = suggest(key, [...allowed]);
+      const suffix = hint ? ` (did you mean --${hint}?)` : '';
+      throw new Error(
+        `Unknown flag --${key} for "${spec.name}"${suffix}\n` +
+        `Run: st ${spec.name} --help`
+      );
+    }
+    const def = spec.flags[key];
+    if (def.requiresValue && flags[key] === true) {
+      throw new Error(`--${key} requires a value (use --${key}=<value>)`);
+    }
+  }
+}
+
+// Levenshtein-free cheap heuristic: suggest the allowed flag with the longest
+// common prefix with the unknown key.
+function suggest(unknown, allowed) {
+  let best = null;
+  let bestLen = 0;
+  for (const a of allowed) {
+    let i = 0;
+    while (i < unknown.length && i < a.length && unknown[i] === a[i]) i++;
+    if (i > bestLen && i >= 2) { best = a; bestLen = i; }
+  }
+  return best;
+}
+
+function printGlobalHelp() {
+  const lines = [
+    '\x1b[1mstaqd\x1b[0m — Stacked PR CLI',
+    '',
+    '\x1b[1mUSAGE\x1b[0m',
+    '  st <command> [options]',
+    '  st <command> --help',
+    '',
+    '\x1b[1mCOMMANDS\x1b[0m',
+  ];
+  const width = Math.max(...Object.keys(COMMANDS).map(n => n.length));
+  for (const name of Object.keys(COMMANDS)) {
+    const { spec } = COMMANDS[name];
+    lines.push(`  ${name.padEnd(width)}  ${spec.summary}`);
+  }
+  lines.push('');
+  lines.push('\x1b[1mGLOBAL OPTIONS\x1b[0m');
+  lines.push('  --help, -h  Show help (global or per-command)');
+  console.log(lines.join('\n'));
+}
+
+function printCommandHelp(spec) {
+  const lines = [
+    `\x1b[1mst ${spec.name}\x1b[0m — ${spec.summary}`,
+    '',
+    '\x1b[1mUSAGE\x1b[0m',
+    `  ${spec.usage}`,
+  ];
+  const flagNames = Object.keys(spec.flags || {});
+  if (flagNames.length) {
+    lines.push('');
+    lines.push('\x1b[1mFLAGS\x1b[0m');
+    const width = Math.max(...flagNames.map(n => n.length + (spec.flags[n].requiresValue ? 8 : 0)));
+    for (const name of flagNames) {
+      const def = spec.flags[name];
+      const label = def.requiresValue ? `--${name}=<value>` : `--${name}`;
+      lines.push(`  ${label.padEnd(width + 2)}  ${def.description}`);
+    }
+  }
+  console.log(lines.join('\n'));
+}

--- a/cli/stack.mjs
+++ b/cli/stack.mjs
@@ -42,8 +42,10 @@ export function buildStackTree(prs) {
 export function findStackFor(branch, roots, nodes) {
   let node = nodes.get(branch);
   if (!node) return null;
-  // Walk up via base to find the stack root
+  const visited = new Set();
   while (nodes.has(node.base)) {
+    if (visited.has(node.branch)) return node; // cycle — treat current as root
+    visited.add(node.branch);
     node = nodes.get(node.base);
   }
   return node;
@@ -53,10 +55,12 @@ export function findStackFor(branch, roots, nodes) {
  * Walk tree in DFS order (parent before children).
  * Calls fn(node, parent) for each node.
  */
-export function walkDFS(node, fn, parent = null) {
+export function walkDFS(node, fn, parent = null, visited = new Set()) {
+  if (visited.has(node)) return;
+  visited.add(node);
   fn(node, parent);
   for (const child of node.children) {
-    walkDFS(child, fn, node);
+    walkDFS(child, fn, node, visited);
   }
 }
 


### PR DESCRIPTION
## Summary

- Hard safety gate in `st submit`: never re-push an already-merged branch (squash-merge detection via merged PR head SHA, patch-id landed check, fail-closed on unknown state)
- Positive ownership required for push: refuse teammate open PRs, closed-unmerged PRs, and fork PRs as authorization signals
- Per-command `--help`, unknown flag rejection with "did you mean" hints, `--dry-run` actually implemented on `create`/`track`/`untrack`/`up`/`down`
- Graphite-style interactive prune prompt in `st sync`; `--prune` stays non-interactive, new `--no-prune` skips
- `st track` cycle defense tightened (pending edge + self-loop), parent detection no longer breaks when parent advances
- `st restack` wraps the walk in `try/finally` so the user always ends up back on the original branch
- Visited-set cycle protection in stack walks

## Safety highlights

`canPush` evaluation order (fail-closed on unknown):

1. `isLandedOn` — patch-id check against `origin/<default>`
2. Merged PR head SHA / merge commit SHA == local tip (stale reused-name local)
3. `hasMyOpenPr` + same-repo head (ownership)
4. Any foreign non-merged PR (open, closed-unmerged, fork) → refuse
5. Prior merged PR history → refuse
6. Otherwise → allow (truly brand-new branch)

Two rounds of adversarial review via `/codex:adversarial-review` — final verdict `SAFE, 0.86` after closing P1 (teammate branch force-push) and P2 (fork PR, closed-unmerged PR) bypasses.

## Commits

- `feat(cli): add git helpers for best-effort fetch and merge detection`
- `fix(cli): refuse to push already-merged branches in st submit`
- `fix(cli): reject st track --parent without a value`
- `feat(cli): add command spec metadata and implement missing --dry-run`
- `feat(cli): per-command --help, unknown flag rejection, spec-driven help`
- `fix(cli): tighten st track cycle defense and loosen parent detection`
- `fix(cli): add cycle protection to stack walks and isAncestor helper`
- `fix(cli): scope st sync --prune to staqd-tracked branches`
- `fix(cli): restore original branch on restack failure, add quiet fetch`
- `feat(cli): prompt before deleting local branches with gone remote`
- `fix(cli): require positive ownership for st submit push gate`

## Test plan

- [ ] `st submit` on a branch whose parent is already merged (local not synced) refuses to re-push the merged parent
- [ ] `st submit` on a squash-merged branch with stale local tip refuses
- [ ] `st sync` prompts per branch with gone remote; `--prune` auto-deletes; `--no-prune` skips
- [ ] `st <cmd> --help` shows per-command help
- [ ] `st submit --dryrun` (typo) produces a "did you mean --dry-run?" error
- [ ] `st track --parent` (no value) errors clearly
- [ ] `st restack` conflict / exception returns the user to the original branch
