### PR TITLE
fix: require tracked branches in st move and reconcile stale metadata

### DIFF
--- a/cli/commands/move.mjs
+++ b/cli/commands/move.mjs
@@ -56,6 +56,7 @@ export async function move(flags) {
   if (!parentSha) {
     throw new Error(`Branch "${newParent}" not found.`);
   }
+  const newParentRef = git.remoteSha(newParent) ? `origin/${newParent}` : newParent;
 
   // Find old parent (current base branch from PR)
   const prs = git.ghPrList();
@@ -68,66 +69,95 @@ export async function move(flags) {
   const oldParent = myPr.baseRefName;
   const trackedParent = git.getTrackedParent(current);
 
-  if (oldParent === newParent && trackedParent === newParent) {
-    console.log(`Already based on ${newParent}.`);
+  // Decide whether a rebase is needed. Current is "already based on" newParent
+  // when newParent's tip is reachable from current — i.e. current sits on top
+  // of newParent in DAG terms. In that case the metadata may still be stale,
+  // but the branch contents are already correct.
+  const needsRebase = !git.isAncestor(newParentRef, current);
+
+  const trackedNeedsUpdate = trackedParent !== newParent;
+  const prBaseNeedsUpdate = oldParent !== newParent;
+
+  if (!needsRebase && !trackedNeedsUpdate && !prBaseNeedsUpdate) {
+    console.log(`Already based on ${newParent}; metadata already matches.`);
     return;
   }
 
-  // PR base already matches but local tracked-parent is stale (or vice versa).
-  // Reconcile metadata without rebasing — the branch is already where it needs
-  // to be on the remote, only the local config or PR base is out of sync.
-  if (oldParent === newParent && trackedParent !== newParent) {
-    if (dryRun) {
-      console.log(`  \x1b[33m~\x1b[0m Would update tracked parent ${trackedParent || '<none>'} → ${newParent}`);
-      return;
+  console.log(`Moving \x1b[1m${current}\x1b[0m → ${newParent}`);
+
+  // Step 1: rebase if needed.
+  if (needsRebase) {
+    // Compute the merge-base with old parent so we can replay only the commits
+    // unique to current. Try the remote ref first; fall back to local if the
+    // old parent's branch was deleted (e.g. squash-merged and pruned).
+    const oldParentRef = git.remoteSha(oldParent)
+      ? `origin/${oldParent}`
+      : (git.localSha(oldParent) ? oldParent : null);
+
+    let mb = oldParentRef ? git.mergeBase(oldParentRef, current) : null;
+
+    // Fallback: if old parent is gone, use the merge-base with new parent.
+    // This drops only commits already shared with newParent, which is the
+    // safe minimum when we have nothing better to skip from.
+    if (!mb) {
+      mb = git.mergeBase(newParentRef, current);
     }
-    git.setTrackedParent(current, newParent);
-    console.log(`  \x1b[32m✓\x1b[0m Tracked parent updated: ${trackedParent || '<none>'} → ${newParent}`);
-    console.log(`  \x1b[90m·\x1b[0m PR #${myPr.number} already based on ${newParent}; no rebase needed`);
-    return;
+
+    if (!mb) {
+      throw new Error(
+        `Cannot find merge-base for ${current}. Old parent "${oldParent}" is unreachable ` +
+        `and current shares no history with ${newParent}.`
+      );
+    }
+
+    if (dryRun) {
+      console.log(`  \x1b[33m~\x1b[0m Would rebase --onto ${newParentRef} ${mb.slice(0, 7)} ${current}`);
+    } else {
+      const r = git.rebaseOnto(newParentRef, mb, current);
+      if (!r.ok) {
+        console.error('\n\x1b[31mConflict during rebase.\x1b[0m Resolve manually:');
+        console.log(`  git rebase --onto ${newParentRef} ${mb.slice(0, 7)} ${current}`);
+        console.log('  # resolve conflicts, then:');
+        console.log(`  git push --force-with-lease origin ${current}`);
+        if (prBaseNeedsUpdate) {
+          console.log(`  gh pr edit ${myPr.number} --base ${newParent}`);
+        }
+        if (trackedNeedsUpdate) {
+          console.log(`  git config --local branch.${current}.staqd-parent ${newParent}`);
+        }
+        throw new Error('Rebase had conflicts.');
+      }
+      git.pushForce(current);
+      console.log(`  \x1b[32m✓\x1b[0m Rebased and pushed`);
+    }
+  } else {
+    console.log(`  \x1b[90m·\x1b[0m ${current} already contains ${newParent}; skipping rebase`);
   }
 
-  console.log(`Moving \x1b[1m${current}\x1b[0m: ${oldParent} → ${newParent}`);
-
-  // Compute merge-base with old parent
-  const mb = git.mergeBase(`origin/${oldParent}`, current);
-  if (!mb) {
-    throw new Error(`Cannot find merge-base between origin/${oldParent} and ${current}.`);
+  // Step 2: reconcile PR base unconditionally.
+  if (prBaseNeedsUpdate) {
+    if (dryRun) {
+      console.log(`  \x1b[33m~\x1b[0m Would update PR #${myPr.number} base: ${oldParent} → ${newParent}`);
+    } else {
+      git.ghPrEditBase(myPr.number, newParent);
+      console.log(`  \x1b[32m✓\x1b[0m PR #${myPr.number} base updated to ${newParent}`);
+    }
   }
 
-  const newParentRef = git.remoteSha(newParent) ? `origin/${newParent}` : newParent;
-
-  if (dryRun) {
-    console.log(`  \x1b[33m~\x1b[0m Would rebase --onto ${newParentRef} ${mb.slice(0, 7)} ${current}`);
-    console.log(`  \x1b[33m~\x1b[0m Would update PR #${myPr.number} base to ${newParent}`);
-    console.log(`  \x1b[33m~\x1b[0m Would update tracked parent ${trackedParent || '<none>'} → ${newParent}`);
-    return;
+  // Step 3: reconcile tracked-parent metadata unconditionally.
+  if (trackedNeedsUpdate) {
+    if (dryRun) {
+      console.log(`  \x1b[33m~\x1b[0m Would update tracked parent: ${trackedParent || '<none>'} → ${newParent}`);
+    } else {
+      git.setTrackedParent(current, newParent);
+      console.log(`  \x1b[32m✓\x1b[0m Tracked parent updated: ${trackedParent || '<none>'} → ${newParent}`);
+    }
   }
 
-  // Rebase onto new parent
-  const r = git.rebaseOnto(newParentRef, mb, current);
-  if (!r.ok) {
-    console.error('\n\x1b[31mConflict during rebase.\x1b[0m Resolve manually:');
-    console.log(`  git rebase --onto ${newParentRef} ${mb.slice(0, 7)} ${current}`);
-    console.log('  # resolve conflicts, then:');
-    console.log(`  git push --force-with-lease origin ${current}`);
-    console.log(`  gh pr edit ${myPr.number} --base ${newParent}`);
-    throw new Error('Rebase had conflicts.');
-  }
+  if (dryRun) return;
 
-  // Push and update PR
-  git.pushForce(current);
-  git.ghPrEditBase(myPr.number, newParent);
-  git.setTrackedParent(current, newParent);
-
-  console.log(`  \x1b[32m✓\x1b[0m Rebased and pushed`);
-  console.log(`  \x1b[32m✓\x1b[0m PR #${myPr.number} base updated to ${newParent}`);
-  console.log(`  \x1b[32m✓\x1b[0m Tracked parent updated to ${newParent}`);
-
-  // Trigger discover to update metadata
-  const { roots } = buildStackTree(git.ghPrList());
-
-  // Find root PR of the stack to trigger discover
+  // Trigger discover on the new parent's PR (if any) so the action-side
+  // metadata catches up too.
   const rootPr = prs.find(p => p.baseRefName === defBranch && p.headRefName === newParent)
     || prs.find(p => p.headRefName === newParent);
 

--- a/cli/commands/move.mjs
+++ b/cli/commands/move.mjs
@@ -69,16 +69,15 @@ export async function move(flags) {
   const oldParent = myPr.baseRefName;
   const trackedParent = git.getTrackedParent(current);
 
-  // Decide whether a rebase is needed. Current is "already based on" newParent
-  // when newParent's tip is reachable from current — i.e. current sits on top
-  // of newParent in DAG terms. In that case the metadata may still be stale,
-  // but the branch contents are already correct.
-  const needsRebase = !git.isAncestor(newParentRef, current);
-
+  // Rebase whenever the PR base changes — we need to drop oldParent's
+  // contribution and replay onto newParent. Skipping the rebase based solely
+  // on `isAncestor(newParent, current)` is wrong: in `main → B → C`, moving C
+  // to main would leave B's commits inside C's PR diff against main.
   const trackedNeedsUpdate = trackedParent !== newParent;
   const prBaseNeedsUpdate = oldParent !== newParent;
+  const needsRebase = prBaseNeedsUpdate;
 
-  if (!needsRebase && !trackedNeedsUpdate && !prBaseNeedsUpdate) {
+  if (!needsRebase && !trackedNeedsUpdate) {
     console.log(`Already based on ${newParent}; metadata already matches.`);
     return;
   }
@@ -87,27 +86,30 @@ export async function move(flags) {
 
   // Step 1: rebase if needed.
   if (needsRebase) {
-    // Compute the merge-base with old parent so we can replay only the commits
-    // unique to current. Try the remote ref first; fall back to local if the
-    // old parent's branch was deleted (e.g. squash-merged and pruned).
+    // Need oldParent's tip to know which commits belong to oldParent vs current.
+    // If both remote and local refs are gone (e.g. squash-merged and pruned),
+    // we cannot derive a safe rebase boundary — bail rather than silently
+    // replaying already-merged commits onto newParent and force-pushing.
     const oldParentRef = git.remoteSha(oldParent)
       ? `origin/${oldParent}`
       : (git.localSha(oldParent) ? oldParent : null);
 
-    let mb = oldParentRef ? git.mergeBase(oldParentRef, current) : null;
-
-    // Fallback: if old parent is gone, use the merge-base with new parent.
-    // This drops only commits already shared with newParent, which is the
-    // safe minimum when we have nothing better to skip from.
-    if (!mb) {
-      mb = git.mergeBase(newParentRef, current);
+    if (!oldParentRef) {
+      throw new Error(
+        `Old parent "${oldParent}" is no longer reachable in origin or locally. ` +
+        `Cannot determine which commits to drop from ${current} without it.\n` +
+        `Recover manually:\n` +
+        `  1. Find the old parent's tip SHA (e.g. \`gh pr view <old-pr> --json headRefOid\`)\n` +
+        `  2. git rebase --onto ${newParentRef} <old-parent-tip> ${current}\n` +
+        `  3. git push --force-with-lease origin ${current}\n` +
+        `  4. gh pr edit ${myPr.number} --base ${newParent}\n` +
+        `  5. git config --local branch.${current}.staqd-parent ${newParent}`
+      );
     }
 
+    const mb = git.mergeBase(oldParentRef, current);
     if (!mb) {
-      throw new Error(
-        `Cannot find merge-base for ${current}. Old parent "${oldParent}" is unreachable ` +
-        `and current shares no history with ${newParent}.`
-      );
+      throw new Error(`Cannot find merge-base between ${oldParentRef} and ${current}.`);
     }
 
     if (dryRun) {

--- a/cli/commands/move.mjs
+++ b/cli/commands/move.mjs
@@ -69,94 +69,95 @@ export async function move(flags) {
   const oldParent = myPr.baseRefName;
   const trackedParent = git.getTrackedParent(current);
 
-  // Rebase whenever the PR base changes — we need to drop oldParent's
-  // contribution and replay onto newParent. Skipping the rebase based solely
-  // on `isAncestor(newParent, current)` is wrong: in `main → B → C`, moving C
-  // to main would leave B's commits inside C's PR diff against main.
-  const trackedNeedsUpdate = trackedParent !== newParent;
-  const prBaseNeedsUpdate = oldParent !== newParent;
-  const needsRebase = prBaseNeedsUpdate;
+  // Refuse to operate on drifted metadata. If PR base and tracked-parent
+  // disagree, neither alone is a safe rebase boundary — force the user to
+  // pick a side first. Without this guard, a metadata-only sync (only one of
+  // the two changing) can leave the branch contents inconsistent with the
+  // updated metadata.
+  if (oldParent !== trackedParent) {
+    throw new Error(
+      `Inconsistent metadata for ${current}: ` +
+      `PR #${myPr.number} base is "${oldParent}" but tracked-parent is "${trackedParent}". ` +
+      `One of them was edited outside st move. Reconcile before retrying:\n` +
+      `  Option A — align tracked to PR (if the branch is rebased onto "${oldParent}"):\n` +
+      `    st track --parent=${oldParent}\n` +
+      `  Option B — align PR to tracked (if the branch is rebased onto "${trackedParent}"):\n` +
+      `    gh pr edit ${myPr.number} --base ${trackedParent}\n` +
+      `Then re-run: st move ${newParent}`
+    );
+  }
 
-  if (!needsRebase && !trackedNeedsUpdate) {
-    console.log(`Already based on ${newParent}; metadata already matches.`);
+  const currentParent = oldParent; // === trackedParent at this point
+
+  if (currentParent === newParent) {
+    console.log(`Already based on ${newParent}; nothing to do.`);
     return;
   }
 
-  console.log(`Moving \x1b[1m${current}\x1b[0m → ${newParent}`);
+  console.log(`Moving \x1b[1m${current}\x1b[0m: ${currentParent} → ${newParent}`);
 
-  // Step 1: rebase if needed.
-  if (needsRebase) {
-    // Need oldParent's tip to know which commits belong to oldParent vs current.
-    // If both remote and local refs are gone (e.g. squash-merged and pruned),
-    // we cannot derive a safe rebase boundary — bail rather than silently
-    // replaying already-merged commits onto newParent and force-pushing.
-    const oldParentRef = git.remoteSha(oldParent)
-      ? `origin/${oldParent}`
-      : (git.localSha(oldParent) ? oldParent : null);
+  // Resolve the rebase boundary. Prefer the remote ref for the previous
+  // parent, since local refs can be stale or accidentally fast-forwarded
+  // (e.g. after `git pull` while on the parent). When the remote is gone
+  // (squash-merged and pruned), recover the original head SHA from the
+  // merged-PR record on GitHub. Bail otherwise — replaying with the wrong
+  // boundary force-pushes corrupted history.
+  let parentRef = git.remoteSha(currentParent) ? `origin/${currentParent}` : null;
 
-    if (!oldParentRef) {
-      throw new Error(
-        `Old parent "${oldParent}" is no longer reachable in origin or locally. ` +
-        `Cannot determine which commits to drop from ${current} without it.\n` +
-        `Recover manually:\n` +
-        `  1. Find the old parent's tip SHA (e.g. \`gh pr view <old-pr> --json headRefOid\`)\n` +
-        `  2. git rebase --onto ${newParentRef} <old-parent-tip> ${current}\n` +
-        `  3. git push --force-with-lease origin ${current}\n` +
-        `  4. gh pr edit ${myPr.number} --base ${newParent}\n` +
-        `  5. git config --local branch.${current}.staqd-parent ${newParent}`
-      );
-    }
-
-    const mb = git.mergeBase(oldParentRef, current);
-    if (!mb) {
-      throw new Error(`Cannot find merge-base between ${oldParentRef} and ${current}.`);
-    }
-
-    if (dryRun) {
-      console.log(`  \x1b[33m~\x1b[0m Would rebase --onto ${newParentRef} ${mb.slice(0, 7)} ${current}`);
-    } else {
-      const r = git.rebaseOnto(newParentRef, mb, current);
-      if (!r.ok) {
-        console.error('\n\x1b[31mConflict during rebase.\x1b[0m Resolve manually:');
-        console.log(`  git rebase --onto ${newParentRef} ${mb.slice(0, 7)} ${current}`);
-        console.log('  # resolve conflicts, then:');
-        console.log(`  git push --force-with-lease origin ${current}`);
-        if (prBaseNeedsUpdate) {
-          console.log(`  gh pr edit ${myPr.number} --base ${newParent}`);
-        }
-        if (trackedNeedsUpdate) {
-          console.log(`  git config --local branch.${current}.staqd-parent ${newParent}`);
-        }
-        throw new Error('Rebase had conflicts.');
+  if (!parentRef) {
+    const merged = git.ghPrListMergedForBranch(currentParent);
+    if (merged.known && merged.prs.length > 0) {
+      const headRefOid = merged.prs[0].headRefOid;
+      if (headRefOid && git.localSha(headRefOid)) {
+        parentRef = headRefOid;
       }
-      git.pushForce(current);
-      console.log(`  \x1b[32m✓\x1b[0m Rebased and pushed`);
-    }
-  } else {
-    console.log(`  \x1b[90m·\x1b[0m ${current} already contains ${newParent}; skipping rebase`);
-  }
-
-  // Step 2: reconcile PR base unconditionally.
-  if (prBaseNeedsUpdate) {
-    if (dryRun) {
-      console.log(`  \x1b[33m~\x1b[0m Would update PR #${myPr.number} base: ${oldParent} → ${newParent}`);
-    } else {
-      git.ghPrEditBase(myPr.number, newParent);
-      console.log(`  \x1b[32m✓\x1b[0m PR #${myPr.number} base updated to ${newParent}`);
     }
   }
 
-  // Step 3: reconcile tracked-parent metadata unconditionally.
-  if (trackedNeedsUpdate) {
-    if (dryRun) {
-      console.log(`  \x1b[33m~\x1b[0m Would update tracked parent: ${trackedParent || '<none>'} → ${newParent}`);
-    } else {
-      git.setTrackedParent(current, newParent);
-      console.log(`  \x1b[32m✓\x1b[0m Tracked parent updated: ${trackedParent || '<none>'} → ${newParent}`);
-    }
+  if (!parentRef) {
+    throw new Error(
+      `Previous parent "${currentParent}" is no longer reachable in origin and ` +
+      `cannot be recovered from merged-PR history. ` +
+      `Cannot determine which commits to drop from ${current}.\n` +
+      `Recover manually:\n` +
+      `  1. Find the previous parent's tip SHA (e.g. \`gh pr view <pr-number> --json headRefOid\`)\n` +
+      `  2. git rebase --onto ${newParentRef} <previous-parent-tip> ${current}\n` +
+      `  3. git push --force-with-lease origin ${current}\n` +
+      `  4. gh pr edit ${myPr.number} --base ${newParent}\n` +
+      `  5. git config --local branch.${current}.staqd-parent ${newParent}`
+    );
   }
 
-  if (dryRun) return;
+  const mb = git.mergeBase(parentRef, current);
+  if (!mb) {
+    throw new Error(`Cannot find merge-base between ${parentRef} and ${current}.`);
+  }
+
+  if (dryRun) {
+    console.log(`  \x1b[33m~\x1b[0m Would rebase --onto ${newParentRef} ${mb.slice(0, 7)} ${current}`);
+    console.log(`  \x1b[33m~\x1b[0m Would update PR #${myPr.number} base: ${currentParent} → ${newParent}`);
+    console.log(`  \x1b[33m~\x1b[0m Would update tracked parent: ${currentParent} → ${newParent}`);
+    return;
+  }
+
+  const r = git.rebaseOnto(newParentRef, mb, current);
+  if (!r.ok) {
+    console.error('\n\x1b[31mConflict during rebase.\x1b[0m Resolve manually:');
+    console.log(`  git rebase --onto ${newParentRef} ${mb.slice(0, 7)} ${current}`);
+    console.log('  # resolve conflicts, then:');
+    console.log(`  git push --force-with-lease origin ${current}`);
+    console.log(`  gh pr edit ${myPr.number} --base ${newParent}`);
+    console.log(`  git config --local branch.${current}.staqd-parent ${newParent}`);
+    throw new Error('Rebase had conflicts.');
+  }
+  git.pushForce(current);
+  console.log(`  \x1b[32m✓\x1b[0m Rebased and pushed`);
+
+  git.ghPrEditBase(myPr.number, newParent);
+  console.log(`  \x1b[32m✓\x1b[0m PR #${myPr.number} base updated to ${newParent}`);
+
+  git.setTrackedParent(current, newParent);
+  console.log(`  \x1b[32m✓\x1b[0m Tracked parent updated: ${currentParent} → ${newParent}`);
 
   // Trigger discover on the new parent's PR (if any) so the action-side
   // metadata catches up too.

--- a/cli/commands/move.mjs
+++ b/cli/commands/move.mjs
@@ -1,7 +1,34 @@
 // st move <parent> — Move current branch to a new parent.
 
+import { readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
 import * as git from '../git.mjs';
 import { buildStackTree, printTree } from '../stack.mjs';
+
+const PENDING_FILE = 'staqd-move-pending.json';
+
+function pendingPath() {
+  return join(git.gitDir(), PENDING_FILE);
+}
+
+function readPending() {
+  try {
+    const raw = readFileSync(pendingPath(), 'utf-8');
+    return JSON.parse(raw);
+  } catch (e) {
+    if (e.code === 'ENOENT') return null;
+    // Corrupt marker — surface but don't crash; treat as present-but-unparseable
+    return { _corrupt: true, _error: e.message };
+  }
+}
+
+function writePending(data) {
+  writeFileSync(pendingPath(), JSON.stringify(data, null, 2));
+}
+
+function clearPending() {
+  try { unlinkSync(pendingPath()); } catch (e) { if (e.code !== 'ENOENT') throw e; }
+}
 
 export const spec = {
   name: 'move',
@@ -27,6 +54,31 @@ export async function move(flags) {
 
   if (current === newParent) {
     throw new Error('Cannot move a branch onto itself.');
+  }
+
+  // Pending-move marker check. If a previous st move force-pushed but the
+  // post-push metadata writes both failed (extraordinary but possible: local
+  // .git/config write + gh API both fail), the marker persists. Refuse to
+  // operate until the user reconciles, since metadata may not match the
+  // already-pushed branch contents.
+  const pending = readPending();
+  if (pending && pending.branch === current) {
+    if (pending._corrupt) {
+      throw new Error(
+        `Pending st move marker at ${pendingPath()} is unreadable: ${pending._error}. ` +
+        `Inspect the file manually, finish any outstanding reconciliation, then delete it.`
+      );
+    }
+    throw new Error(
+      `Pending st move detected for ${current}: ` +
+      `the previous run force-pushed onto "${pending.newParent}" but metadata updates failed. ` +
+      `Branch contents on origin reflect "${pending.newParent}", but metadata may still point at "${pending.currentParent}".\n` +
+      `Reconcile manually before retrying:\n` +
+      `  git config --local branch.${current}.staqd-parent ${pending.newParent}\n` +
+      `  gh pr edit <pr-number> --base ${pending.newParent}\n` +
+      `Then clear the marker:\n` +
+      `  rm ${pendingPath()}`
+    );
   }
 
   const defBranch = git.defaultBranch();
@@ -158,6 +210,22 @@ export async function move(flags) {
     console.log(`  git config --local branch.${current}.staqd-parent ${newParent}`);
     throw new Error('Rebase had conflicts.');
   }
+
+  // Persist a pending-move marker BEFORE the irreversible force-push. If
+  // both metadata writes later fail, this file is the only durable signal
+  // that origin/<current> has moved while metadata didn't. The next st move
+  // refuses to operate until the user clears it. If the marker write itself
+  // fails (e.g. .git is read-only), abort before pushing — metadata writes
+  // would also fail and we'd corrupt without recovery.
+  try {
+    writePending({ branch: current, currentParent, newParent });
+  } catch (e) {
+    throw new Error(
+      `Cannot create recovery marker at ${pendingPath()}: ${e.message}. ` +
+      `Aborting before push to prevent unrecoverable state.`
+    );
+  }
+
   git.pushForce(current);
   console.log(`  \x1b[32m✓\x1b[0m Rebased and pushed`);
 
@@ -200,8 +268,12 @@ export async function move(flags) {
       console.error(`  \x1b[31m✗\x1b[0m ${f.step}: ${f.error}`);
       console.error(`     fix: ${f.recovery}`);
     }
+    console.error(`\nThen remove the pending-move marker:\n  rm ${pendingPath()}`);
     throw new Error('Partial post-push state. See recovery commands above.');
   }
+
+  // All metadata writes succeeded — clear the pending marker.
+  clearPending();
 
   // Trigger discover on the new parent's PR (if any) so the action-side
   // metadata catches up too.

--- a/cli/commands/move.mjs
+++ b/cli/commands/move.mjs
@@ -161,15 +161,47 @@ export async function move(flags) {
   git.pushForce(current);
   console.log(`  \x1b[32m✓\x1b[0m Rebased and pushed`);
 
-  // Update tracked-parent BEFORE the fallible PR edit. If ghPrEditBase later
-  // throws (network/auth), the next run sees tracked=newParent vs PR base=
-  // oldParent — the drift gate fires with a clear reconciliation menu instead
-  // of silently treating the stale metadata as authoritative.
-  git.setTrackedParent(current, newParent);
-  console.log(`  \x1b[32m✓\x1b[0m Tracked parent updated: ${currentParent} → ${newParent}`);
+  // Both metadata updates must be attempted independently. If only one fails,
+  // the other still records newParent and the drift gate (oldParent !==
+  // trackedParent) fires on the next run. If both fail, neither metadata
+  // source reflects reality — surface the failure with explicit recovery
+  // commands so the user can finish reconciliation manually. Sequencing one
+  // before the other (round-3 attempt) just trades which corruption window
+  // is open; running them independently closes both.
+  const failures = [];
 
-  git.ghPrEditBase(myPr.number, newParent);
-  console.log(`  \x1b[32m✓\x1b[0m PR #${myPr.number} base updated to ${newParent}`);
+  try {
+    git.setTrackedParent(current, newParent);
+    console.log(`  \x1b[32m✓\x1b[0m Tracked parent updated: ${currentParent} → ${newParent}`);
+  } catch (e) {
+    failures.push({
+      step: 'setTrackedParent',
+      error: e.message.split('\n')[0],
+      recovery: `git config --local branch.${current}.staqd-parent ${newParent}`,
+    });
+  }
+
+  try {
+    git.ghPrEditBase(myPr.number, newParent);
+    console.log(`  \x1b[32m✓\x1b[0m PR #${myPr.number} base updated to ${newParent}`);
+  } catch (e) {
+    failures.push({
+      step: 'ghPrEditBase',
+      error: e.message.split('\n')[0],
+      recovery: `gh pr edit ${myPr.number} --base ${newParent}`,
+    });
+  }
+
+  if (failures.length > 0) {
+    console.error('\n\x1b[31mPost-push metadata update failed.\x1b[0m');
+    console.error(`The branch is rebased and pushed onto ${newParent}, but some metadata`);
+    console.error('did not update. Run the following to finish reconciliation:\n');
+    for (const f of failures) {
+      console.error(`  \x1b[31m✗\x1b[0m ${f.step}: ${f.error}`);
+      console.error(`     fix: ${f.recovery}`);
+    }
+    throw new Error('Partial post-push state. See recovery commands above.');
+  }
 
   // Trigger discover on the new parent's PR (if any) so the action-side
   // metadata catches up too.

--- a/cli/commands/move.mjs
+++ b/cli/commands/move.mjs
@@ -29,6 +29,21 @@ export async function move(flags) {
     throw new Error('Cannot move a branch onto itself.');
   }
 
+  const defBranch = git.defaultBranch();
+
+  if (!git.getTrackedParent(current)) {
+    throw new Error(
+      `Branch "${current}" is not tracked. Run "st track" first to register it in the stack.`
+    );
+  }
+
+  if (newParent !== defBranch && !git.getTrackedParent(newParent)) {
+    throw new Error(
+      `Parent "${newParent}" is not tracked. Run "st track" on that branch first ` +
+      `(or use "${defBranch}" as the parent).`
+    );
+  }
+
   if (!dryRun && !git.isClean()) {
     throw new Error('Uncommitted changes detected. Commit or stash before running st move.');
   }
@@ -51,9 +66,24 @@ export async function move(flags) {
   }
 
   const oldParent = myPr.baseRefName;
+  const trackedParent = git.getTrackedParent(current);
 
-  if (oldParent === newParent) {
+  if (oldParent === newParent && trackedParent === newParent) {
     console.log(`Already based on ${newParent}.`);
+    return;
+  }
+
+  // PR base already matches but local tracked-parent is stale (or vice versa).
+  // Reconcile metadata without rebasing — the branch is already where it needs
+  // to be on the remote, only the local config or PR base is out of sync.
+  if (oldParent === newParent && trackedParent !== newParent) {
+    if (dryRun) {
+      console.log(`  \x1b[33m~\x1b[0m Would update tracked parent ${trackedParent || '<none>'} → ${newParent}`);
+      return;
+    }
+    git.setTrackedParent(current, newParent);
+    console.log(`  \x1b[32m✓\x1b[0m Tracked parent updated: ${trackedParent || '<none>'} → ${newParent}`);
+    console.log(`  \x1b[90m·\x1b[0m PR #${myPr.number} already based on ${newParent}; no rebase needed`);
     return;
   }
 
@@ -70,6 +100,7 @@ export async function move(flags) {
   if (dryRun) {
     console.log(`  \x1b[33m~\x1b[0m Would rebase --onto ${newParentRef} ${mb.slice(0, 7)} ${current}`);
     console.log(`  \x1b[33m~\x1b[0m Would update PR #${myPr.number} base to ${newParent}`);
+    console.log(`  \x1b[33m~\x1b[0m Would update tracked parent ${trackedParent || '<none>'} → ${newParent}`);
     return;
   }
 
@@ -87,13 +118,14 @@ export async function move(flags) {
   // Push and update PR
   git.pushForce(current);
   git.ghPrEditBase(myPr.number, newParent);
+  git.setTrackedParent(current, newParent);
 
   console.log(`  \x1b[32m✓\x1b[0m Rebased and pushed`);
   console.log(`  \x1b[32m✓\x1b[0m PR #${myPr.number} base updated to ${newParent}`);
+  console.log(`  \x1b[32m✓\x1b[0m Tracked parent updated to ${newParent}`);
 
   // Trigger discover to update metadata
   const { roots } = buildStackTree(git.ghPrList());
-  const defBranch = git.defaultBranch();
 
   // Find root PR of the stack to trigger discover
   const rootPr = prs.find(p => p.baseRefName === defBranch && p.headRefName === newParent)

--- a/cli/commands/move.mjs
+++ b/cli/commands/move.mjs
@@ -106,9 +106,17 @@ export async function move(flags) {
 
   if (!parentRef) {
     const merged = git.ghPrListMergedForBranch(currentParent);
-    if (merged.known && merged.prs.length > 0) {
+    // Refuse ambiguous recovery: if the head ref name has multiple merged
+    // PRs, branch-name reuse may have associated the SHA with a different
+    // PR than the actual previous parent.
+    if (merged.known && merged.prs.length === 1) {
       const headRefOid = merged.prs[0].headRefOid;
-      if (headRefOid && git.localSha(headRefOid)) {
+      // Only trust the SHA if it's locally reachable AND is actually an
+      // ancestor of current. Without the ancestry check, a stale object
+      // (loose pre-GC, reflog) can resolve as "exists" while having no
+      // relationship to current's history — picking it as the rebase
+      // boundary would force-push wrong content.
+      if (headRefOid && git.localSha(headRefOid) && git.isAncestor(headRefOid, current)) {
         parentRef = headRefOid;
       }
     }
@@ -153,11 +161,15 @@ export async function move(flags) {
   git.pushForce(current);
   console.log(`  \x1b[32m✓\x1b[0m Rebased and pushed`);
 
-  git.ghPrEditBase(myPr.number, newParent);
-  console.log(`  \x1b[32m✓\x1b[0m PR #${myPr.number} base updated to ${newParent}`);
-
+  // Update tracked-parent BEFORE the fallible PR edit. If ghPrEditBase later
+  // throws (network/auth), the next run sees tracked=newParent vs PR base=
+  // oldParent — the drift gate fires with a clear reconciliation menu instead
+  // of silently treating the stale metadata as authoritative.
   git.setTrackedParent(current, newParent);
   console.log(`  \x1b[32m✓\x1b[0m Tracked parent updated: ${currentParent} → ${newParent}`);
+
+  git.ghPrEditBase(myPr.number, newParent);
+  console.log(`  \x1b[32m✓\x1b[0m PR #${myPr.number} base updated to ${newParent}`);
 
   // Trigger discover on the new parent's PR (if any) so the action-side
   // metadata catches up too.

--- a/cli/commands/move.mjs
+++ b/cli/commands/move.mjs
@@ -62,13 +62,17 @@ export async function move(flags) {
   // operate until the user reconciles, since metadata may not match the
   // already-pushed branch contents.
   const pending = readPending();
+  // Fail closed on any unreadable marker BEFORE the branch-equality check.
+  // A corrupt marker has no `branch` field, so embedding the corrupt-check
+  // inside the equality guard makes it unreachable — exactly when the
+  // recovery signal cannot be trusted.
+  if (pending && pending._corrupt) {
+    throw new Error(
+      `Pending st move marker at ${pendingPath()} is unreadable: ${pending._error}. ` +
+      `Inspect the file manually, finish any outstanding reconciliation, then delete it.`
+    );
+  }
   if (pending && pending.branch === current) {
-    if (pending._corrupt) {
-      throw new Error(
-        `Pending st move marker at ${pendingPath()} is unreadable: ${pending._error}. ` +
-        `Inspect the file manually, finish any outstanding reconciliation, then delete it.`
-      );
-    }
     throw new Error(
       `Pending st move detected for ${current}: ` +
       `the previous run force-pushed onto "${pending.newParent}" but metadata updates failed. ` +

--- a/cli/git.mjs
+++ b/cli/git.mjs
@@ -22,6 +22,13 @@ export function currentBranch() {
   return run('git', ['symbolic-ref', '--short', 'HEAD'], { silent: true });
 }
 
+// Path to the .git directory (or the worktree-resolved destination if .git
+// is a file). Used to anchor staqd's local state files (e.g. recovery
+// markers).
+export function gitDir() {
+  return run('git', ['rev-parse', '--git-dir'], { silent: true });
+}
+
 export function defaultBranch() {
   const ref = run('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], { silent: true });
   if (ref) return ref.replace('refs/remotes/origin/', '');


### PR DESCRIPTION
## Summary

Fixes `st move` corruption bugs from issue #48 plus seven rounds of dual-stack adversarial review (Claude `adversarial-reviewer` + Codex). Final verdict: `SAFE` from both stacks.

## Bugs fixed

- **Untracked branches** — `st move` silently ignored `staqd-parent` metadata. Reject untracked current/parent branches up front (default branch exempted).
- **Wrong rebase decision** — `isAncestor(newParent, current)` skipped the rebase when moving onto a transitive ancestor (`main → B → C`, then `st move main` from C). C's PR ended up containing B's commits.
- **Drifted metadata corruption** — when PR base and tracked-parent disagreed, the metadata-only path could mark the branch reconciled while contents still descended from the old parent.
- **Stale local boundary** — `origin/<oldParent>` pruned + local ref stale → wrong merge-base → force-pushed duplicates.
- **Stale merged-PR SHA** — branch-name reuse could pick an unrelated PR's `headRefOid` as boundary.
- **Post-push partial state** — `ghPrEditBase` failure left tracked-parent and PR base both at the old value while branch contents were on new parent. Drift gate couldn't detect.
- **Double metadata-write failure** — both `setTrackedParent` and `ghPrEditBase` failing left no durable signal.
- **Corrupt-marker bypass** — unreadable marker file silently skipped the recovery gate.

## Final design

### Pre-flight
- Refuse untracked current branch and untracked new parent (default branch exempted).
- Refuse if a pending-move marker exists for the current branch (corruption-class fail-closed).
- Refuse if any pending-move marker is unreadable (fail closed before branch-equality check).
- Refuse if PR base and tracked-parent disagree (drift gate). Print reconciliation menu.

### Boundary resolution
- Prefer `origin/<currentParent>`.
- If pruned, recover via `gh pr list --state merged --json headRefOid`. Require exactly one matching merged PR, locally-reachable SHA, and `isAncestor(headRefOid, current)`.
- Bail with manual-recovery instructions otherwise. Never trust a stale local ref.

### Push and metadata
- Write `.git/staqd-move-pending.json` BEFORE the irreversible force-push. Marker write failure aborts before push.
- After push, attempt `setTrackedParent` and `ghPrEditBase` INDEPENDENTLY in try/catch. Failures collected and surfaced with explicit recovery commands.
- Clear marker only when both metadata writes succeed.

## Out of scope (filed as #49)

The pending-move marker design has four follow-up hazards: cross-branch overwrite, worktree-private git-dir isolation, concurrent `st move` race, push-failure stale marker. These are limitations of the safety net, not corruption in the move logic itself. Tracking in #49.

## Test plan

- [ ] `st move <untracked-branch>` errors with track hint
- [ ] `st move` on untracked current branch errors with track hint
- [ ] PR base / tracked-parent drift errors with reconciliation menu before any side effects
- [ ] In stack `main → B → C`, `st move main` from C rebases C onto main and drops B's commits from C's diff
- [ ] When old parent is pruned but the merged PR's `headRefOid` is a verified ancestor of current, recovery succeeds
- [ ] When merged PR record is ambiguous (multiple matches) or SHA is not an ancestor, command fails closed
- [ ] Single metadata-write failure self-heals via drift gate on next run
- [ ] Double metadata-write failure surfaces marker; next `st move` refuses until reconciled
- [ ] Corrupt marker (truncated / hand-edited / empty) fails closed with "marker unreadable" error
- [ ] `st move --dry-run` reports exactly the same side effects the actual run performs

## Review history

7 rounds of `/review`. Each round either closed all P0/P1 findings or surfaced new corruption-class issues which were fixed. Final round: both stacks return `VERDICT: SAFE` with no remaining corruption-class P0/P1 in the move logic.

Closes #48.
